### PR TITLE
Don't use key.json

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -12,6 +12,8 @@
 .index_updated
 teams
 
+key.json
+
 __pycache__/
 bin/
 compiled/

--- a/model_trainer.py
+++ b/model_trainer.py
@@ -24,7 +24,6 @@ import time
 import traceback
 
 # Other Modules
-from google.oauth2 import service_account
 import googleapiclient.discovery
 import tensorflow as tf
 from tensorflow.core.util import event_pb2
@@ -340,10 +339,8 @@ def cancel_training_model(team_uuid, model_uuid):
     return storage.cancel_training_requested(team_uuid, model_uuid)
 
 def __get_ml_service():
-    scopes = ['https://www.googleapis.com/auth/cloud-platform']
-    credentials = service_account.Credentials.from_service_account_file('key.json', scopes=scopes)
     return googleapiclient.discovery.build(
-        serviceName='ml', version='v1', credentials=credentials, cache_discovery=False)
+        serviceName='ml', version='v1', cache_discovery=False)
 
 def __get_parent():
     # TODO(lizlooney): Is the project id here supposed to be our Google Cloud Project ID?

--- a/util.py
+++ b/util.py
@@ -44,7 +44,7 @@ def make_label_map(sorted_label_list):
 
 
 def storage_client():
-    return google.cloud.storage.Client.from_service_account_json('key.json')
+    return google.cloud.storage.Client()
 
 def extend_dict_label_to_count(dict, other_dict):
     for label, count in other_dict.items():


### PR DESCRIPTION
Added key.json to .gcloudignore.
Modified model_trainer.__get_ml_service so it doesn't use key.json.
Modified util.storage_client so it doesn't use key.json.