### PR TITLE
Fixed 2 problems with the train more dialog:

### DIFF
--- a/server/src/js/trainMoreDialog.js
+++ b/server/src/js/trainMoreDialog.js
@@ -64,6 +64,7 @@ fmltc.TrainMoreDialog = function(
 
   // Create checkboxes for the datasets. Check and disable the checkboxes that correspond to
   // datasets that are already part of this model.
+  this.datasetContainerDiv.innerHTML = ''; // Remove previous children.
   for (let i = 0; i < this.datasetEntities.length; i++) {
     const checkbox = document.createElement('input');
     this.checkboxes[i] = checkbox;

--- a/server/static/css/styles.css
+++ b/server/static/css/styles.css
@@ -168,6 +168,7 @@ body {
   display: inline-block;
   min-width: 500px;
   text-align: left;
+  margin-top: 100px;
   padding: 16px;
   border: 3px solid #000;
   background-color: #fefefe;


### PR DESCRIPTION
1. The top of the dialog was under the header, so the close button was not available.
2. The checkboxes for adding additional datasets were not cleared, so each time you open the dialog, it adds more checkboxes for the same dataset names.