### PR TITLE
Ignore duplicate actions so we don't start unnecessary cloud functions

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -115,3 +115,9 @@ indexes:
   properties:
   - name: action_uuid
   - name: create_time
+
+- kind: Action
+  properties:
+  - name: team_uuid
+  - name: action_name
+  - name: create_time

--- a/server/dataset_producer.py
+++ b/server/dataset_producer.py
@@ -59,7 +59,8 @@ def prepare_to_start_dataset_production(team_uuid, description, video_uuids_json
     return dataset_uuid
 
 def make_action_parameters(team_uuid, dataset_uuid, video_uuids_json, eval_percent, create_time_ms):
-    action_parameters = action.create_action_parameters(action.ACTION_NAME_DATASET_PRODUCE)
+    action_parameters = action.create_action_parameters(
+        team_uuid, action.ACTION_NAME_DATASET_PRODUCE)
     action_parameters['team_uuid'] = team_uuid
     action_parameters['dataset_uuid'] = dataset_uuid
     action_parameters['video_uuids_json'] = video_uuids_json
@@ -122,7 +123,8 @@ def produce_dataset(action_parameters):
     train_record_number = 0
     eval_record_number = 0
 
-    action_parameters = action.create_action_parameters(action.ACTION_NAME_DATASET_PRODUCE_RECORD)
+    action_parameters = action.create_action_parameters(
+        team_uuid, action.ACTION_NAME_DATASET_PRODUCE_RECORD)
     action_parameters['team_uuid'] = team_uuid
     action_parameters['dataset_uuid'] = dataset_uuid
     action_parameters['sorted_label_list'] = sorted_label_list

--- a/server/dataset_zipper.py
+++ b/server/dataset_zipper.py
@@ -41,7 +41,8 @@ def prepare_to_zip_dataset(team_uuid, dataset_uuid):
     return dataset_zip_uuid, partition_count
 
 def make_action_parameters(team_uuid, dataset_uuid, dataset_zip_uuid, partition_count):
-    action_parameters = action.create_action_parameters(action.ACTION_NAME_DATASET_ZIP)
+    action_parameters = action.create_action_parameters(
+        team_uuid, action.ACTION_NAME_DATASET_ZIP)
     action_parameters['team_uuid'] = team_uuid
     action_parameters['dataset_uuid'] = dataset_uuid
     action_parameters['dataset_zip_uuid'] = dataset_zip_uuid
@@ -62,7 +63,8 @@ def zip_dataset(action_parameters):
         partition_lists[(i + 1) % partition_count].append(dataset_record_entity['tf_record_blob_name'])
 
     # Trigger actions for the partitions
-    action_parameters = action.create_action_parameters(action.ACTION_NAME_DATASET_ZIP_PARTITION)
+    action_parameters = action.create_action_parameters(
+        team_uuid, action.ACTION_NAME_DATASET_ZIP_PARTITION)
     action_parameters['team_uuid'] = team_uuid
     action_parameters['dataset_zip_uuid'] = dataset_zip_uuid
     for partition_index, partition_list in enumerate(partition_lists):

--- a/server/frame_extractor.py
+++ b/server/frame_extractor.py
@@ -33,7 +33,8 @@ import storage
 import util
 
 def start_wait_for_video_upload(team_uuid, video_uuid, description, video_filename, file_size, content_type, create_time_ms):
-    action_parameters = action.create_action_parameters(action.ACTION_NAME_WAIT_FOR_VIDEO_UPLOAD)
+    action_parameters = action.create_action_parameters(
+        team_uuid, action.ACTION_NAME_WAIT_FOR_VIDEO_UPLOAD)
     action_parameters['team_uuid'] = team_uuid
     action_parameters['video_uuid'] = video_uuid
     action_parameters['description'] = description
@@ -94,7 +95,8 @@ def maybe_restart_frame_extraction(team_uuid, video_uuid):
 
 
 def __start_frame_extraction(video_entity):
-    action_parameters = action.create_action_parameters(action.ACTION_NAME_FRAME_EXTRACTION)
+    action_parameters = action.create_action_parameters(
+        video_entity['team_uuid'], action.ACTION_NAME_FRAME_EXTRACTION)
     action_parameters['team_uuid'] = video_entity['team_uuid']
     action_parameters['video_uuid'] = video_entity['video_uuid']
     action.trigger_action_via_blob(action_parameters)

--- a/server/model_trainer.py
+++ b/server/model_trainer.py
@@ -443,7 +443,8 @@ def maybe_restart_monitor_training(team_uuid, model_uuid):
 
 def __start_monitor_training(team_uuid, model_uuid):
     model_entity = storage.prepare_to_start_monitor_training(team_uuid, model_uuid)
-    action_parameters = action.create_action_parameters(action.ACTION_NAME_MONITOR_TRAINING)
+    action_parameters = action.create_action_parameters(
+        team_uuid, action.ACTION_NAME_MONITOR_TRAINING)
     action_parameters['team_uuid'] = team_uuid
     action_parameters['model_uuid'] = model_uuid
     action.trigger_action_via_blob(action_parameters)

--- a/server/tflite_creator.py
+++ b/server/tflite_creator.py
@@ -38,7 +38,8 @@ import util
 
 
 def trigger_create_tflite(team_uuid, model_uuid):
-    action_parameters = action.create_action_parameters(action.ACTION_NAME_CREATE_TFLITE)
+    action_parameters = action.create_action_parameters(
+        team_uuid, action.ACTION_NAME_CREATE_TFLITE)
     action_parameters['team_uuid'] = team_uuid
     action_parameters['model_uuid'] = model_uuid
     action.trigger_action_via_blob(action_parameters)

--- a/server/tracking.py
+++ b/server/tracking.py
@@ -59,9 +59,12 @@ def validate_tracker_name(s):
 
 
 def prepare_to_start_tracking(team_uuid, video_uuid, tracker_name, scale, init_frame_number, init_bboxes_text):
-    metrics.save_tracking_metrics(tracker_name, scale, bbox_writer.count_boxes(init_bboxes_text))
+    # storage.tracker_starting will raise HttpErrorConflict if tracking is already in progress on
+    # this video.
     tracker_uuid = storage.tracker_starting(team_uuid, video_uuid, tracker_name, scale, init_frame_number, init_bboxes_text)
-    action_parameters = action.create_action_parameters(action.ACTION_NAME_TRACKING)
+    metrics.save_tracking_metrics(tracker_name, scale, bbox_writer.count_boxes(init_bboxes_text))
+    action_parameters = action.create_action_parameters(
+        team_uuid, action.ACTION_NAME_TRACKING)
     action_parameters['video_uuid'] = video_uuid
     action_parameters['tracker_uuid'] = tracker_uuid
     action.trigger_action_via_blob(action_parameters)


### PR DESCRIPTION
Modified action.create_action_parameters to take team_uuid parameter.
Added code to storage.py to retrieve actions by team uuid and action name.
If a new action contains the same parameters as an existing action, ignore the new one.