### PR TITLE
Display proper version on login and header, plus small misc.

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Write Properties
       run: |
-        echo "{ \"version\" : \"$(git rev-parse --short $GITHUB_SHA) \" }" > server/application.properties
+        echo "{ \"version\" : \"$(git rev-parse --short $GITHUB_SHA) \" }" > server/app.properties
 
     - name: Closure Build
       run: ./gradlew compileJavascript

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -27,6 +27,10 @@ jobs:
         echo "${{secrets.SERVICE_KEY}}" | base64 --decode > key.json
         echo "${{secrets.OIDC_SECRETS}}" | base64 --decode > client_secrets.json
 
+    - name: Write Properties
+      run: |
+        echo "{ \"version\" : \"$(git rev-parse --short $GITHUB_SHA) \" }" > server/application.properties
+
     - name: Closure Build
       run: ./gradlew compileJavascript
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ teams
 venv*
 generated/
 .idea/
-terraform/dev/.terraform/
+terraform/dev/.terraform*
+terraform/dev/*.tfstate

--- a/server/app.properties
+++ b/server/app.properties
@@ -1,0 +1,3 @@
+{
+  "version": "development"
+}

--- a/server/constants.py
+++ b/server/constants.py
@@ -30,3 +30,6 @@ USE_OIDC = os.getenv('USE_OIDC')
 
 # REDIS_IP_ADDR may be set in the environment in app engine, but not cloud functions.
 REDIS_IP_ADDR = os.getenv('REDIS_IP_ADDR')
+
+# Expects to be 'development' or 'production'
+ENVIRONMENT = os.getenv('ENVIRONMENT')

--- a/server/main.py
+++ b/server/main.py
@@ -49,18 +49,22 @@ from roles import Role
 
 app = flask.Flask(__name__)
 app.config.update(
-    MAX_CONTENT_LENGTH=8 * 1024 * 1024,
-    ALLOWED_EXTENSIONS=set(['png', 'jpg', 'jpeg', 'gif'])
 )
 
 app.config.update(
     {
+        # Flask properties
         "SECRET_KEY": cloud_secrets.get("flask_secret_key"),
-        "TESTING": True,
-        "DEBUG": True,
+        "MAX_CONTENT_LENGTH": 8 * 1024 * 1024,
+        "ALLOWED_EXTENSIONS": {'png', 'jpg', 'jpeg', 'gif'},
+
+        # OIDC properties
         "OIDC_ID_TOKEN_COOKIE_SECURE": False,
         "OIDC_REQUIRE_VERIFIED_EMAIL": False,
-        "OIDC_SCOPES": ["openid", "email", "roles"]
+        "OIDC_SCOPES": ["openid", "email", "roles"],
+
+        # "TESTING": True,
+        # "DEBUG": True,
     }
 )
 

--- a/server/main.py
+++ b/server/main.py
@@ -48,8 +48,6 @@ import util
 from roles import Role
 
 app = flask.Flask(__name__)
-app.config.update(
-)
 
 app.config.update(
     {

--- a/server/main.py
+++ b/server/main.py
@@ -60,9 +60,6 @@ app.config.update(
         "OIDC_ID_TOKEN_COOKIE_SECURE": False,
         "OIDC_REQUIRE_VERIFIED_EMAIL": False,
         "OIDC_SCOPES": ["openid", "email", "roles"],
-
-        # "TESTING": True,
-        # "DEBUG": True,
     }
 )
 

--- a/server/roles.py
+++ b/server/roles.py
@@ -14,15 +14,31 @@
 
 from enum import Enum
 
+import util
+
 
 class Role(str, Enum):
+    GLOBAL_ADMIN = 'GLOBAL_ADMIN'
+    ML_DEVELOPER = 'ML_DEVELOPER'
     TEAM_ADMIN = 'TEAM_ADMIN'
     TEAM_MEMBER = 'TEAM_MEMBER'
 
 
 def can_upload_video(roles):
-    if Role.TEAM_ADMIN in roles:
-        return True
+    return Role.TEAM_ADMIN in roles
+
+
+def can_login(roles):
+    if util.is_development_env():
+        return is_global_admin(roles) or is_ml_developer(roles)
     else:
-        return False
+        return True
+
+
+def is_global_admin(roles):
+    return Role.GLOBAL_ADMIN in roles
+
+
+def is_ml_developer(roles):
+    return Role.ML_DEVELOPER in roles
 

--- a/server/templates/login.html
+++ b/server/templates/login.html
@@ -74,7 +74,7 @@ limitations under the License.
 			<img class="mb-4" src="https://www.firstinspires.org/sites/all/themes/first/assets/images/2020/first-horz-rgb.png" alt="" style="width: 250px; height: auto;">
 			
 			<h1 class="h3 mb-3 fw-bold">First Machine<br>Learning Toolchain</h1>
-			<h2 class="h2 mb-3 fst-italic">Version 0.0001</h2>
+			<h2 class="h2 mb-3 fst-italic">Version {{version}}</h2>
 
 			<div class="form-floating">              
 				<select name="program" id="program" class="form-control">

--- a/server/templates/root.html
+++ b/server/templates/root.html
@@ -39,7 +39,7 @@ limitations under the License.
     <div class="container">
       <nav class="navbar navbar-expand-md navbar-dark fixed-top pt-0">
         <div class="container bg-dark d-block" style="height: 111px;">
-          <span class="d-block w-100 fs-3" style="text-align:center;color:#fff;"><span class="fst-italic">FIRST</span> Machine Learning Toolchain</span>
+          <span class="d-block w-100 fs-3" style="text-align:center;color:#fff;"><span class="fst-italic">FIRST</span> Machine Learning Toolchain - {{version}}</span>
 
           <a class="navbar-brand" href="/">
             <img src="https://ftc-cloud-cdn.global-prod.ftclive.org/img/logo_horiz-4bc1dfb53e3adb7bb4458755.png" width="199" height="60" class="d-inline-block align-center" alt="">

--- a/server/templates/selectTeam.html
+++ b/server/templates/selectTeam.html
@@ -64,7 +64,7 @@ limitations under the License.
     <img class="mb-4" src="https://www.firstinspires.org/sites/all/themes/first/assets/images/2020/first-horz-rgb.png" alt="" style="width: 250px; height: auto;">
 
     <h1 class="h3 mb-3 fw-bold">First Machine<br>Learning Toolchain</h1>
-    <h2 class="h2 mb-3 fst-italic">Version 0.0001</h2>
+    <h2 class="h2 mb-3 fst-italic">Version {{version}}</h2>
 
     <label for="teamNumber">Team Number</label>
     <select id="teamNumber" name=team_num class="form-control" method="post" action="/">

--- a/server/util.py
+++ b/server/util.py
@@ -28,6 +28,8 @@ import cloud_secrets
 import constants
 
 LOG_MESSAGE_PREFIX = 'FMLTC_LOG - '
+ENV_DEVELOPMENT = "development"
+ENV_PRODUCTION = "production"
 
 def log(message):
     logging.critical('%s%s' % (LOG_MESSAGE_PREFIX, message))
@@ -61,3 +63,17 @@ def extend_dict_label_to_count(dict, other_dict):
             dict[label] += count
         else:
             dict[label] = count
+
+
+def is_development_env():
+    if (constants.ENVIRONMENT == ENV_DEVELOPMENT):
+        return True
+    else:
+        return False
+
+
+def is_production_env():
+    if (constants.ENVIRONMENT == ENV_PRODUCTION):
+        return True
+    else:
+        return False

--- a/terraform/core/main.tf
+++ b/terraform/core/main.tf
@@ -103,7 +103,7 @@ resource "google_cloudfunctions_function" "perform-action" {
   source_archive_object = google_storage_bucket_object.cloud-function-archive.name
 
   environment_variables = {
-    project_id = var.project_id
+    PROJECT_ID = var.project_id
   }
 
   timeouts {

--- a/terraform/core/main.tf
+++ b/terraform/core/main.tf
@@ -243,6 +243,7 @@ resource "google_app_engine_standard_app_version" "fmltc-app-v1" {
     ORIGIN = var.project_url
     USE_OIDC = "true"
     REDIS_IP_ADDR = google_redis_instance.ml-redis-dev.host
+    ENVIRONMENT = "development"
   }
 
   depends_on = [module.serverless-connector]


### PR DESCRIPTION
Update: 8de2592 adds a distinction between a development and production environment and restricts the development environment to users with either the global admin or ml developer role.

This diff does the following:

  - Creates an app.properties file to store a version string.
  - On merge of any PR, the commit hash is used as the version string for the development environment.
  - On startup, reads the app.properties and passes the version along to pages that need to display it.
  - Fixes the PROJECT_ID environment variable casing for the cloud function.
  - Fixes/adds a proper flask secret.  Prior to this change I believe it was using the empty string for dev.

Note that production will have a different yaml file for deployment and that yaml will use the release version, not a commit hash for generating the app.properties file that contains the version string.


