### PR TITLE
Fixed bugs, including issue 119

### DIFF
--- a/server/model_trainer.py
+++ b/server/model_trainer.py
@@ -340,7 +340,7 @@ def is_done(model_entity):
         __is_done(model_entity['train_job_state']) and
         __is_done(model_entity['eval_job_state']))
 
-def cancel_training_model(team_uuid, model_uuid):
+def stop_training_model(team_uuid, model_uuid):
     # retrieve_model_entity will raise HttpErrorNotFound
     # if the team_uuid/model_uuid is not found.
     model_entity = retrieve_model_entity(team_uuid, model_uuid)
@@ -350,7 +350,7 @@ def cancel_training_model(team_uuid, model_uuid):
             train_job_name = __get_train_job_name(model_uuid)
             ml.projects().jobs().cancel(name=train_job_name).execute()
         except:
-            util.log('model_trainer.cancel_training_model - canceling training job - except %s' %
+            util.log('model_trainer.stop_training_model - canceling training job - except %s' %
                 traceback.format_exc().replace('\n', ' ... '))
     if model_entity['eval_job']:
         if __is_alive(model_entity['eval_job_state']):
@@ -358,9 +358,9 @@ def cancel_training_model(team_uuid, model_uuid):
                 eval_job_name = __get_eval_job_name(model_uuid)
                 ml.projects().jobs().cancel(name=eval_job_name).execute()
             except:
-                util.log('model_trainer.cancel_training_model - canceling eval job - except %s' %
+                util.log('model_trainer.stop_training_model - canceling eval job - except %s' %
                     traceback.format_exc().replace('\n', ' ... '))
-    return storage.cancel_training_requested(team_uuid, model_uuid)
+    return storage.stop_training_requested(team_uuid, model_uuid)
 
 def __get_ml_service():
     payload = cloud_secrets.get("key_json")

--- a/server/src/js/deleteConfirmationDialog.js
+++ b/server/src/js/deleteConfirmationDialog.js
@@ -35,14 +35,15 @@ fmltc.DeleteConfirmationDialog = function(util, title, message, onYes) {
   this.onYes = onYes;
   this.dialog = document.getElementById('deleteConfirmationDialog');
   this.backdrop = document.getElementsByClassName('modal-backdrop')[0];
-  this.yesButton = document.getElementById('dcYesButton');
+  this.xButton = document.getElementById('dcXButton');
   this.noButton = document.getElementById('dcNoButton');
+  this.yesButton = document.getElementById('dcYesButton');
 
   document.getElementById('dcTitleDiv').textContent = title;
   document.getElementById('dcMessageDiv').textContent = message;
 
+  this.xButton.onclick = this.noButton.onclick = this.noButton_onclick.bind(this);
   this.yesButton.onclick = this.yesButton_onclick.bind(this);
-  this.noButton.onclick = this.noButton_onclick.bind(this);
   this.dialog.style.display = 'block';
 };
 
@@ -57,8 +58,8 @@ fmltc.DeleteConfirmationDialog.prototype.yesButton_onclick = function() {
 
 fmltc.DeleteConfirmationDialog.prototype.dismiss = function() {
   // Clear event handlers.
+  this.xButton.onclick = this.noButton.onclick = null;
   this.yesButton.onclick = null;
-  this.noButton.onclick = null;
 
   // Hide the dialog.
   this.dialog.style.display = 'none';

--- a/server/src/js/deleteForbiddenDialog.js
+++ b/server/src/js/deleteForbiddenDialog.js
@@ -34,6 +34,7 @@ fmltc.DeleteForbiddenDialog = function(util, title, message, list) {
   this.util = util;
   this.dialog = document.getElementById('deleteForbiddenDialog');
   this.backdrop = document.getElementsByClassName('modal-backdrop')[0];
+  this.xButton = document.getElementById('dfXButton');
   this.okButton = document.getElementById('dfOKButton');
 
   document.getElementById('dfTitleDiv').textContent = title;
@@ -48,13 +49,13 @@ fmltc.DeleteForbiddenDialog = function(util, title, message, list) {
     }
   }
 
-  this.okButton.onclick = this.okButton_onclick.bind(this);
+  this.xButton.onclick = this.okButton.onclick = this.okButton_onclick.bind(this);
   this.dialog.style.display = 'block';
 };
 
 fmltc.DeleteForbiddenDialog.prototype.okButton_onclick = function() {
   // Clear event handlers.
-  this.okButton.onclick = null;
+  this.xButton.onclick = this.okButton.onclick = null;
 
   // Hide the dialog.
   this.dialog.style.display = 'none';

--- a/server/src/js/downloadDatasetDialog.js
+++ b/server/src/js/downloadDatasetDialog.js
@@ -37,7 +37,8 @@ fmltc.DownloadDatasetDialog = function(util, datasetEntity, downloadStartTime) {
 
   this.dialog = document.getElementById('downloadDatasetDialog');
   this.backdrop = document.getElementsByClassName('modal-backdrop')[0];
-  this.dismissButton = document.getElementById('ddDismissButton');
+  this.xButton = document.getElementById('ddXButton');
+  this.closeButton = document.getElementById('ddCloseButton');
   this.partitionCountDiv = document.getElementById('ddPartitionCountDiv');
   this.partitionCountSpan = document.getElementById('ddPartitionCountSpan');
   this.progressDiv = document.getElementById('ddProgressDiv');
@@ -58,15 +59,15 @@ fmltc.DownloadDatasetDialog = function(util, datasetEntity, downloadStartTime) {
   this.progressDiv.style.visibility = 'hidden';
   this.progressDiv.innerHTML = ''; // Remove all children
   this.finishedDiv.style.visibility = 'hidden';
-  this.dismissButton.disabled = true;
+  this.xButton.disabled = this.closeButton.disabled = true;
 
-  this.dismissButton.onclick = this.dismissButton_onclick.bind(this);
+  this.xButton.onclick = this.closeButton.onclick = this.closeButton_onclick.bind(this);
   this.dialog.style.display = 'block';
 
   this.prepareToZipDataset();
 };
 
-fmltc.DownloadDatasetDialog.prototype.dismissButton_onclick = function() {
+fmltc.DownloadDatasetDialog.prototype.closeButton_onclick = function() {
   this.downloadStartedArray = [];
   this.downloadFinishedArray = [];
   this.zipProgressArray = [];
@@ -80,7 +81,7 @@ fmltc.DownloadDatasetDialog.prototype.dismissButton_onclick = function() {
   this.finishedDiv.style.visibility = 'hidden';
 
   // Clear event handlers.
-  this.dismissButton.onclick = null;
+  this.xButton.onclick = this.closeButton.onclick = null;
 
   // Hide the dialog.
   this.dialog.style.display = 'none';
@@ -308,8 +309,8 @@ fmltc.DownloadDatasetDialog.prototype.allDone = function(datasetZipUuid) {
           datasetZipUuid, partitionIndex, 0), 30000);
   }
 
-  this.dismissButton.disabled = false;
-  setTimeout(this.dismissButton_onclick.bind(this), 1000);
+  this.xButton.disabled = this.closeButton.disabled = false;
+  setTimeout(this.closeButton_onclick.bind(this), 1000);
 };
 
 fmltc.DownloadDatasetDialog.prototype.deleteDatasetZip = function(datasetZipUuid, partitionIndex, failureCount) {

--- a/server/src/js/downloadModelDialog.js
+++ b/server/src/js/downloadModelDialog.js
@@ -38,11 +38,12 @@ fmltc.DownloadModelDialog = function(util, modelUuid, downloadStartTime, onModel
 
   this.dialog = document.getElementById('downloadModelDialog');
   this.backdrop = document.getElementsByClassName('modal-backdrop')[0];
-  this.dismissButton = document.getElementById('dmDismissButton');
+  this.xButton = document.getElementById('dmXButton');
+  this.closeButton = document.getElementById('dmCloseButton');
 
-  this.dismissButton.disabled = true;
+  this.xButton.disabled = this.closeButton.disabled = true;
 
-  this.dismissButton.onclick = this.dismissButton_onclick.bind(this);
+  this.xButton.onclick = this.closeButton.onclick = this.closeButton_onclick.bind(this);
   this.dialog.style.display = 'block';
 
   setTimeout(this.getTFLiteDownloadUrl.bind(this), 5000);
@@ -64,9 +65,9 @@ fmltc.DownloadModelDialog.prototype.xhr_getTFLiteDownloadUrl_onreadystatechange 
     if (xhr.status === 200) {
       const response = JSON.parse(xhr.responseText);
       if (response.exists) {
-        this.dismissButton.disabled = false;
+        this.xButton.disabled = this.closeButton.disabled = false;
         this.onModelReady(this.downloadStartTime, response.download_url);
-        setTimeout(this.dismissButton_onclick.bind(this), 1000);
+        setTimeout(this.closeButton_onclick.bind(this), 1000);
 
       } else {
         setTimeout(this.getTFLiteDownloadUrl.bind(this, this.modelUuid, this.downloadStartTime), 5000);
@@ -80,9 +81,9 @@ fmltc.DownloadModelDialog.prototype.xhr_getTFLiteDownloadUrl_onreadystatechange 
   }
 };
 
-fmltc.DownloadModelDialog.prototype.dismissButton_onclick = function() {
+fmltc.DownloadModelDialog.prototype.closeButton_onclick = function() {
   // Clear event handlers.
-  this.dismissButton.onclick = null;
+  this.xButton.onclick = this.closeButton.onclick = null;
 
   // Hide the dialog.
   this.dialog.style.display = 'none';

--- a/server/src/js/labelVideo.js
+++ b/server/src/js/labelVideo.js
@@ -39,7 +39,7 @@ fmltc.LabelVideo = function(util, videoEntity, videoFrameEntity0) {
 
   this.startTime = Date.now();
 
-  this.dismissButton = document.getElementById('dismissButton');
+  this.backButton = document.getElementById('backButton');
   this.smallerImageButton = document.getElementById('smallerImageButton');
   this.largerImageButton = document.getElementById('largerImageButton');
   this.loadingProgress = document.getElementById('loadingProgress');
@@ -158,7 +158,7 @@ fmltc.LabelVideo.prototype.setVideoEntity = function(videoEntity) {
   this.rescaleCanvas();
   window.addEventListener('resize', this.repositionCanvas.bind(this));
 
-  this.dismissButton.onclick = this.dismissButton_onclick.bind(this);
+  this.backButton.onclick = this.backButton_onclick.bind(this);
   this.smallerImageButton.onclick = this.smallerImageButton_onclick.bind(this);
   this.largerImageButton.onclick = this.largerImageButton_onclick.bind(this);
   this.bboxCanvas.onmousedown = this.bboxCanvas_onmousedown.bind(this);
@@ -187,8 +187,8 @@ fmltc.LabelVideo.prototype.setVideoEntity = function(videoEntity) {
   this.updateUI();
 };
 
-fmltc.LabelVideo.prototype.dismissButton_onclick = function() {
-  this.dismissButton.disabled = true;
+fmltc.LabelVideo.prototype.backButton_onclick = function() {
+  this.backButton.disabled = true;
   this.saveBboxes(this.dismissAfterSaveBboxes.bind(this));
 };
 
@@ -196,7 +196,7 @@ fmltc.LabelVideo.prototype.dismissAfterSaveBboxes = function(success) {
   if (success) {
     window.history.back();
   } else {
-    this.dismissButton.disabled = false;
+    this.backButton.disabled = false;
   }
 };
 

--- a/server/src/js/monitorTraining.js
+++ b/server/src/js/monitorTraining.js
@@ -39,7 +39,7 @@ fmltc.MonitorTraining = function(util, modelUuid, modelEntitiesByUuid, datasetEn
   this.datasetEntitiesByUuid = datasetEntitiesByUuid;
 
   this.activeTrainingDiv = document.getElementById('activeTrainingDiv');
-  this.cancelTrainingButton = document.getElementById('cancelTrainingButton');
+  this.stopTrainingButton = document.getElementById('stopTrainingButton');
   this.refreshIntervalRangeInput = document.getElementById('refreshIntervalRangeInput');
   this.refreshButton = document.getElementById('refreshButton');
   this.trainTimeTd = document.getElementById('trainTimeTd');
@@ -144,8 +144,8 @@ fmltc.MonitorTraining = function(util, modelUuid, modelEntitiesByUuid, datasetEn
   this.util.addTabResizeListener(this.tab_onresize.bind(this));
   this.util.addTabClickListener(this.tab_onclick.bind(this));
 
-  document.getElementById('dismissButton').onclick = this.dismissButton_onclick.bind(this);
-  this.cancelTrainingButton.onclick = this.cancelTrainingButton_onclick.bind(this);
+  document.getElementById('backButton').onclick = this.backButton_onclick.bind(this);
+  this.stopTrainingButton.onclick = this.stopTrainingButton_onclick.bind(this);
   this.refreshIntervalRangeInput.onchange = this.refreshIntervalRangeInput_onchange.bind(this);
   this.refreshButton.onclick = this.refreshButton_onclick.bind(this);
   this.firstPageButton.onclick = this.firstPageButton_onclick.bind(this);
@@ -154,33 +154,33 @@ fmltc.MonitorTraining = function(util, modelUuid, modelEntitiesByUuid, datasetEn
   this.lastPageButton.onclick = this.lastPageButton_onclick.bind(this);
 };
 
-fmltc.MonitorTraining.prototype.dismissButton_onclick = function() {
+fmltc.MonitorTraining.prototype.backButton_onclick = function() {
   window.history.back();
 };
 
 fmltc.MonitorTraining.prototype.updateButtons = function() {
-  let canCancelTraining = true;
+  let canStopTraining = true;
   if (this.util.isTrainingDone(this.modelEntity)) {
-    canCancelTraining = false;
+    canStopTraining = false;
   } else {
     if (this.modelEntity.cancel_requested) {
-      canCancelTraining = false;
+      canStopTraining = false;
     }
   }
 
-  this.cancelTrainingButton.disabled = !canCancelTraining;
+  this.stopTrainingButton.disabled = !canStopTraining;
 };
 
-fmltc.MonitorTraining.prototype.cancelTrainingButton_onclick = function() {
+fmltc.MonitorTraining.prototype.stopTrainingButton_onclick = function() {
   const xhr = new XMLHttpRequest();
   const params = 'model_uuid=' + encodeURIComponent(this.modelUuid);
-  xhr.open('POST', '/cancelTrainingModel', true);
+  xhr.open('POST', '/stopTrainingModel', true);
   xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
-  xhr.onreadystatechange = this.xhr_cancelTraining_onreadystatechange.bind(this, xhr, params);
+  xhr.onreadystatechange = this.xhr_stopTraining_onreadystatechange.bind(this, xhr, params);
   xhr.send(params);
 };
 
-fmltc.MonitorTraining.prototype.xhr_cancelTraining_onreadystatechange = function(xhr, params) {
+fmltc.MonitorTraining.prototype.xhr_stopTraining_onreadystatechange = function(xhr, params) {
   if (xhr.readyState === 4) {
     xhr.onreadystatechange = null;
 
@@ -191,7 +191,7 @@ fmltc.MonitorTraining.prototype.xhr_cancelTraining_onreadystatechange = function
 
     } else {
       // TODO(lizlooney): handle error properly
-      console.log('Failure! /cancelTraining?' + params +
+      console.log('Failure! /stopTraining?' + params +
           ' xhr.status is ' + xhr.status + '. xhr.statusText is ' + xhr.statusText);
     }
   }
@@ -631,7 +631,7 @@ fmltc.MonitorTraining.prototype.updateModelUI = function() {
   }
 
   document.getElementById('trainStateTd').textContent = this.util.formatJobState(
-      'train', this.modelEntity.cancel_requested, this.modelEntity.train_job_state);
+      'train', this.modelEntity);
 
   document.getElementById('numStepsCompletedTd').textContent =
       new Number(this.modelEntity.trained_steps).toLocaleString();
@@ -644,7 +644,7 @@ fmltc.MonitorTraining.prototype.updateModelUI = function() {
   }
 
   document.getElementById('evalStateTd').textContent = this.util.formatJobState(
-      'eval', this.modelEntity.cancel_requested, this.modelEntity.eval_job_state);
+      'eval', this.modelEntity);
 
   this.modelLoader.style.visibility = 'hidden';
 };

--- a/server/src/js/startTrainingDialog.js
+++ b/server/src/js/startTrainingDialog.js
@@ -38,7 +38,8 @@ fmltc.StartTrainingDialog = function(
   this.onTrainingStarted = onTrainingStarted;
   this.dialog = document.getElementById('startTrainingDialog');
   this.backdrop = document.getElementsByClassName('modal-backdrop')[0];
-  this.dismissButton = document.getElementById('stDismissButton');
+  this.xButton = document.getElementById('stXButton');
+  this.closeButton = document.getElementById('stCloseButton');
   this.maxRunningMinutesInput = document.getElementById('stMaxRunningMinutesInput');
   this.totalTrainingMinutesSpan = document.getElementById('stTotalTrainingMinutesSpan');
   this.remainingTrainingMinutesSpan = document.getElementById('stRemainingTrainingMinutesSpan');
@@ -79,7 +80,7 @@ fmltc.StartTrainingDialog = function(
   this.successDiv.style.display = 'none';
   this.failedDiv.style.display = 'none';
 
-  this.dismissButton.onclick = this.dismissButton_onclick.bind(this);
+  this.xButton.onclick = this.closeButton.onclick = this.closeButton_onclick.bind(this);
   this.numTrainingStepsInput.onchange = this.numTrainingStepsInput_onchange.bind(this);
   this.maxRunningMinutesInput.onchange = this.maxRunningMinutesInput_onchange.bind(this);
   this.descriptionInput.oninput = this.descriptionInput_oninput.bind(this);
@@ -87,9 +88,9 @@ fmltc.StartTrainingDialog = function(
   this.dialog.style.display = 'block';
 };
 
-fmltc.StartTrainingDialog.prototype.dismissButton_onclick = function() {
+fmltc.StartTrainingDialog.prototype.closeButton_onclick = function() {
   // Clear event handlers.
-  this.dismissButton.onclick = null;
+  this.xButton.onclick = this.closeButton.onclick = null;
   this.descriptionInput.oninput = null;
   this.startButton.onclick = null;
 
@@ -166,7 +167,7 @@ fmltc.StartTrainingDialog.prototype.xhr_startTrainingModel_onreadystatechange = 
       this.util.clearWaitCursor();
 
       this.onTrainingStarted(remainingTrainingMinutes, modelEntity);
-      setTimeout(this.dismissButton_onclick.bind(this), 1000);
+      setTimeout(this.closeButton_onclick.bind(this), 1000);
 
     } else {
       // TODO(lizlooney): handle error properly

--- a/server/src/js/trainMoreDialog.js
+++ b/server/src/js/trainMoreDialog.js
@@ -40,7 +40,8 @@ fmltc.TrainMoreDialog = function(
   this.onTrainingStarted = onTrainingStarted;
   this.dialog = document.getElementById('trainMoreDialog');
   this.backdrop = document.getElementsByClassName('modal-backdrop')[0];
-  this.dismissButton = document.getElementById('tmDismissButton');
+  this.xButton = document.getElementById('tmXButton');
+  this.closeButton = document.getElementById('tmCloseButton');
   this.maxRunningMinutesInput = document.getElementById('tmMaxRunningMinutesInput');
   this.totalTrainingMinutesSpan = document.getElementById('tmTotalTrainingMinutesSpan');
   this.remainingTrainingMinutesSpan = document.getElementById('tmRemainingTrainingMinutesSpan');
@@ -97,7 +98,7 @@ fmltc.TrainMoreDialog = function(
   this.successDiv.style.display = 'none';
   this.failedDiv.style.display = 'none';
 
-  this.dismissButton.onclick = this.dismissButton_onclick.bind(this);
+  this.xButton.onclick = this.closeButton.onclick = this.closeButton_onclick.bind(this);
   this.numTrainingStepsInput.onchange = this.numTrainingStepsInput_onchange.bind(this);
   this.maxRunningMinutesInput.onchange = this.maxRunningMinutesInput_onchange.bind(this);
   this.descriptionInput.oninput = this.descriptionInput_oninput.bind(this);
@@ -114,9 +115,9 @@ fmltc.TrainMoreDialog.prototype.isDatasetInModel = function(datasetEntity) {
   return false;
 };
 
-fmltc.TrainMoreDialog.prototype.dismissButton_onclick = function() {
+fmltc.TrainMoreDialog.prototype.closeButton_onclick = function() {
   // Clear event handlers.
-  this.dismissButton.onclick = null;
+  this.xButton.onclick = this.closeButton.onclick = null;
   this.descriptionInput.oninput = null;
   this.startButton.onclick = null;
 
@@ -201,7 +202,7 @@ fmltc.TrainMoreDialog.prototype.xhr_startTrainingModel_onreadystatechange = func
       this.util.clearWaitCursor();
 
       this.onTrainingStarted(remainingTrainingMinutes, modelEntity);
-      setTimeout(this.dismissButton_onclick.bind(this), 1000);
+      setTimeout(this.closeButton_onclick.bind(this), 1000);
 
     } else {
       // TODO(lizlooney): handle error properly

--- a/server/src/js/uploadVideoFileDialog.js
+++ b/server/src/js/uploadVideoFileDialog.js
@@ -34,88 +34,105 @@ fmltc.UploadVideoFileDialog = function(util, onVideoUploaded) {
   this.util = util;
   this.onVideoUploaded = onVideoUploaded;
   this.dialog = document.getElementById('uploadVideoFileDialog');
-  this.dismissButton = document.getElementById('uvfDismissButton');
+  this.xButton = document.getElementById('uvfXButton');
+  this.closeButton = document.getElementById('uvfCloseButton');
   this.videoFileInput = document.getElementById('uvfVideoFileInput');
   this.descriptionInput = document.getElementById('uvfDescriptionInput');
   this.uploadButton = document.getElementById('uvfUploadButton');
-  this.uploadingH3 = document.getElementById('uvfUploadingH3');
   this.uploadingState = document.getElementById('uvfUploadingState');
+  this.uploadingProgressHeader = document.getElementById('uvfUploadingProgressHeader');
   this.uploadingProgress = document.getElementById('uvfUploadingProgress');
   this.uploadingFailedDiv = document.getElementById('uvfUploadingFailedDiv');
   // Bootstrap modal backdrop
   this.backdrop = document.getElementsByClassName('modal-backdrop')[0];
 
+  this.videoFileInput.value = '';
   this.descriptionInput.value = '';
 
-  this.dismissButton.onclick = this.dismissButton_onclick.bind(this);
+  this.xButton.onclick = this.closeButton.onclick = this.closeButton_onclick.bind(this);
   this.videoFileInput.onchange = this.videoFileInput_onchange.bind(this);
   this.descriptionInput.oninput = this.descriptionInput_oninput.bind(this);
   this.uploadButton.onclick = this.uploadButton_onclick.bind(this);
 
+  this.state = -1;
   this.setState(fmltc.UploadVideoFileDialog.STATE_ZERO);
+  this.dialog.style.display = 'block';
 };
 
 fmltc.UploadVideoFileDialog.STATE_ZERO = 0;
-fmltc.UploadVideoFileDialog.STATE_FILE_CHOSEN = 1;
-fmltc.UploadVideoFileDialog.STATE_PREPARING_TO_UPLOAD = 2;
-fmltc.UploadVideoFileDialog.STATE_PREPARING_TO_UPLOAD_FAILED = 3;
-fmltc.UploadVideoFileDialog.STATE_UPLOADING = 4;
-fmltc.UploadVideoFileDialog.STATE_UPLOADING_FAILED = 5;
-fmltc.UploadVideoFileDialog.STATE_UPLOADING_FINISHED = 6;
-fmltc.UploadVideoFileDialog.STATE_EXTRACTION_STARTING = 7;
+fmltc.UploadVideoFileDialog.STATE_PREPARING_TO_UPLOAD = 1;
+fmltc.UploadVideoFileDialog.STATE_PREPARE_TO_UPLOAD_FAILED = 2;
+fmltc.UploadVideoFileDialog.STATE_UPLOADING = 3;
+fmltc.UploadVideoFileDialog.STATE_UPLOADING_FAILED = 4;
+fmltc.UploadVideoFileDialog.STATE_UPLOADING_FINISHED = 5;
+fmltc.UploadVideoFileDialog.STATE_EXTRACTION_STARTING = 6;
+fmltc.UploadVideoFileDialog.STATE_UPLOADING_MAY_HAVE_FAILED = 7;
 
 fmltc.UploadVideoFileDialog.prototype.setState = function(state, optMessage) {
+  const oldState = this.state;
   this.state = state;
-  switch (this.state) {
-    case fmltc.UploadVideoFileDialog.STATE_ZERO:
-      this.videoFileInput.value = '';
-      this.videoFileInput.disabled = false;
-      this.dismissButton.disabled = false;
-      this.updateUploadButton();
-      this.uploadingH3.style.visibility = 'hidden';
-      this.uploadingState.textContent = '';
-      this.uploadingProgress.style.visibility = 'hidden';
-      this.uploadingFailedDiv.style.display = 'none';
-      this.dialog.style.display = 'block';
-      break;
-    case fmltc.UploadVideoFileDialog.STATE_FILE_CHOSEN:
-      this.updateUploadButton();
-      break;
-    case fmltc.UploadVideoFileDialog.STATE_PREPARING_TO_UPLOAD:
-      this.dismissButton.disabled = true;
-      this.updateUploadButton();
-      this.uploadingState.textContent = 'Preparing to upload the video file.';
-      this.uploadingH3.style.visibility = 'visible';
-      this.uploadingProgress.style.visibility = 'visible';
-      this.videoFileInput.disabled = true;
-      break;
-    case fmltc.UploadVideoFileDialog.STATE_PREPARING_TO_UPLOAD_FAILED:
-      this.uploadingState.textContent = optMessage ? optMessage : 'Unable to upload video at this time. Please wait a few minutes and try again.';
-      this.dismissButton.disabled = false;
-      break;
-    case fmltc.UploadVideoFileDialog.STATE_UPLOADING:
-      this.uploadingState.textContent = 'Uploading the video file.';
-      break;
-    case fmltc.UploadVideoFileDialog.STATE_UPLOADING_FAILED:
-      this.uploadingState.textContent = '';
-      this.dismissButton.disabled = false;
-      this.uploadingFailedDiv.style.display = 'block';
-      break;
-    case fmltc.UploadVideoFileDialog.STATE_UPLOADING_FINISHED:
-      this.uploadingState.textContent = 'Finished uploading the video file. Please wait for frame extraction to begin.';
-      break;
-    case fmltc.UploadVideoFileDialog.STATE_EXTRACTION_STARTING:
-      this.uploadingState.textContent = 'Starting to extract frames from the video file.';
-      this.dismissButton.disabled = false;
-      break;
+
+  this.updateUploadButton();
+
+  if (this.state != oldState) {
+    switch (this.state) {
+      case fmltc.UploadVideoFileDialog.STATE_ZERO:
+        // STATE_ZERO is used when the dialog first appears and also if the user chooses a different
+        // file or modifies the description after /prepareToUploadVideo has failed.
+        this.xButton.disabled = this.closeButton.disabled = false;
+        this.videoFileInput.disabled = false;
+        this.descriptionInput.disabled = false;
+        this.uploadingState.innerHTML = '&nbsp;';
+        this.uploadingProgressHeader.style.display = 'none';
+        this.uploadingProgress.style.display = 'none';
+        this.uploadingFailedDiv.style.display = 'none';
+        break;
+      case fmltc.UploadVideoFileDialog.STATE_PREPARING_TO_UPLOAD:
+        this.xButton.disabled = this.closeButton.disabled = true;
+        this.uploadingState.textContent = 'Preparing to upload the video file.';
+        this.videoFileInput.disabled = true;
+        this.descriptionInput.disabled = true;
+        break;
+      case fmltc.UploadVideoFileDialog.STATE_PREPARE_TO_UPLOAD_FAILED:
+        this.xButton.disabled = this.closeButton.disabled = false;
+        this.videoFileInput.disabled = false;
+        this.descriptionInput.disabled = false;
+        this.uploadingState.textContent = optMessage
+            ? optMessage : 'Unable to upload video at this time. Please wait a few minutes and try again.';
+        break;
+      case fmltc.UploadVideoFileDialog.STATE_UPLOADING:
+        this.xButton.disabled = this.closeButton.disabled = true;
+        this.uploadingState.textContent = 'Uploading the video file.';
+        this.uploadingProgressHeader.style.display = 'block';
+        this.uploadingProgress.style.display = 'block';
+        break;
+      case fmltc.UploadVideoFileDialog.STATE_UPLOADING_FAILED:
+        this.xButton.disabled = this.closeButton.disabled = false;
+        this.uploadingState.textContent = 'Unable to upload the video file.';
+        this.uploadingFailedDiv.style.display = 'block';
+        break;
+      case fmltc.UploadVideoFileDialog.STATE_UPLOADING_FINISHED:
+        this.xButton.disabled = this.closeButton.disabled = true;
+        this.uploadingState.textContent = 'Finished uploading the video file. Please wait for frame extraction to begin.';
+        break;
+      case fmltc.UploadVideoFileDialog.STATE_EXTRACTION_STARTING:
+        this.xButton.disabled = this.closeButton.disabled = false;
+        this.uploadingState.textContent = 'Starting to extract frames from the video file.';
+        break;
+      case fmltc.UploadVideoFileDialog.STATE_UPLOADING_MAY_HAVE_FAILED:
+        this.xButton.disabled = this.closeButton.disabled = false;
+        this.uploadingState.textContent = 'Unable to determine whether the video was uploaded. Please refresh and check the Videos tab.';
+        this.uploadingFailedDiv.style.display = 'block';
+        break;
+    }
   }
 };
 
-fmltc.UploadVideoFileDialog.prototype.dismissButton_onclick = function() {
+fmltc.UploadVideoFileDialog.prototype.closeButton_onclick = function() {
   // Clear event handlers.
   this.videoFileInput.onchange = null;
   this.descriptionInput.oninput = null;
-  this.dismissButton.onclick = null;
+  this.xButton.onclick = this.closeButton.onclick = null;
   this.uploadButton.onclick = null;
 
   // Hide the dialog.
@@ -124,23 +141,22 @@ fmltc.UploadVideoFileDialog.prototype.dismissButton_onclick = function() {
 };
 
 fmltc.UploadVideoFileDialog.prototype.videoFileInput_onchange = function() {
-  if (this.videoFileInput.files.length == 0) {
-    this.setState(fmltc.UploadVideoFileDialog.ZERO);
-  } else {
-    this.setState(fmltc.UploadVideoFileDialog.STATE_FILE_CHOSEN);
-  }
+  this.setState(fmltc.UploadVideoFileDialog.STATE_ZERO);
 };
 
 fmltc.UploadVideoFileDialog.prototype.descriptionInput_oninput = function() {
-  this.updateUploadButton();
+  this.setState(fmltc.UploadVideoFileDialog.STATE_ZERO);
 };
 
 fmltc.UploadVideoFileDialog.prototype.updateUploadButton = function() {
-  this.uploadButton.disabled = (
-      this.videoFileInput.files.length == 0 ||
-      this.videoFileInput.files[0].size == 0 ||
-      this.descriptionInput.value.length == 0 ||
-      this.descriptionInput.value.length > 30);
+  if (this.state == fmltc.UploadVideoFileDialog.STATE_ZERO) {
+    this.uploadButton.disabled = (
+        this.videoFileInput.files.length == 0 ||
+        this.descriptionInput.value.length == 0 ||
+        this.descriptionInput.value.length > 30);
+  } else {
+    this.uploadButton.disabled = true;
+  }
 };
 
 fmltc.UploadVideoFileDialog.prototype.uploadButton_onclick = function() {
@@ -152,10 +168,10 @@ fmltc.UploadVideoFileDialog.prototype.uploadButton_onclick = function() {
   this.uploadingProgress.max = videoFile.size;
   this.setState(fmltc.UploadVideoFileDialog.STATE_PREPARING_TO_UPLOAD);
 
-  this.prepareToUploadVideo(description, videoFile, createTimeMs);
+  this.prepareToUploadVideo(description, videoFile, createTimeMs, 0);
 }
 
-fmltc.UploadVideoFileDialog.prototype.prepareToUploadVideo = function(description, videoFile, createTimeMs) {
+fmltc.UploadVideoFileDialog.prototype.prepareToUploadVideo = function(description, videoFile, createTimeMs, failureCount) {
   const xhr = new XMLHttpRequest();
   const params = 'description=' + encodeURIComponent(description) +
       '&video_filename=' + encodeURIComponent(videoFile.name) +
@@ -166,12 +182,12 @@ fmltc.UploadVideoFileDialog.prototype.prepareToUploadVideo = function(descriptio
   xhr.open('POST', '/prepareToUploadVideo', true);
   xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
   xhr.onreadystatechange = this.xhr_prepareToUploadVideo_onreadystatechange.bind(this, xhr, params,
-      description, videoFile, createTimeMs);
+      description, videoFile, createTimeMs, failureCount);
   xhr.send(params);
 };
 
 fmltc.UploadVideoFileDialog.prototype.xhr_prepareToUploadVideo_onreadystatechange = function(xhr, params,
-    description, videoFile, createTimeMs) {
+    description, videoFile, createTimeMs, failureCount) {
   if (xhr.readyState === 4) {
     xhr.onreadystatechange = null;
 
@@ -181,14 +197,18 @@ fmltc.UploadVideoFileDialog.prototype.xhr_prepareToUploadVideo_onreadystatechang
         this.setState(fmltc.UploadVideoFileDialog.STATE_UPLOADING);
         this.uploadVideoFile(response.upload_url, response.video_uuid, description, videoFile, createTimeMs);
       } else {
-        this.setState(fmltc.UploadVideoFileDialog.STATE_PREPARING_TO_UPLOAD_FAILED, response.message);
+        this.setState(fmltc.UploadVideoFileDialog.STATE_PREPARE_TO_UPLOAD_FAILED, response.message);
       }
 
     } else {
-      console.log('Failure! /prepareToUploadVideo?' + params +
-          ' xhr.status is ' + xhr.status + '. xhr.statusText is ' + xhr.statusText);
-      console.log('Will retry /prepareToUploadVideo?' + params + ' in 1 seconds.');
-      setTimeout(this.prepareToUploadVideo.bind(this, description, videoFile, createTimeMs), 1000);
+      failureCount++;
+      if (failureCount < 5 && xhr.status != 400) {
+        const delay = Math.pow(2, failureCount);
+        console.log('Will retry /prepareToUploadVideo?' + params + ' in ' + delay + ' seconds.');
+        setTimeout(this.prepareToUploadVideo.bind(this, description, videoFile, createTimeMs, failureCount), delay * 1000);
+      } else {
+        this.setState(fmltc.UploadVideoFileDialog.STATE_PREPARE_TO_UPLOAD_FAILED);
+      }
     }
   }
 };
@@ -216,28 +236,27 @@ fmltc.UploadVideoFileDialog.prototype.xhr_uploadVideoFile_onreadystatechange = f
     if (xhr.status === 200) {
       this.uploadingProgress.value = this.uploadingProgress.max;
       this.setState(fmltc.UploadVideoFileDialog.STATE_UPLOADING_FINISHED);
-      setTimeout(this.doesVideoEntityExist.bind(this, videoUuid), 10000);
+      setTimeout(this.doesVideoEntityExist.bind(this, videoUuid, 0), 10000);
 
     } else {
-      // TODO(lizlooney): handle error properly
       console.log('Failure! uploading videoFile xhr.status is ' + xhr.status + '. xhr.statusText is ' + xhr.statusText);
       this.setState(fmltc.UploadVideoFileDialog.STATE_UPLOADING_FAILED);
     }
   }
 };
 
-fmltc.UploadVideoFileDialog.prototype.doesVideoEntityExist = function(videoUuid) {
+fmltc.UploadVideoFileDialog.prototype.doesVideoEntityExist = function(videoUuid, failureCount) {
   const xhr = new XMLHttpRequest();
   const params = 'video_uuid=' + encodeURIComponent(videoUuid)
   xhr.open('POST', '/doesVideoEntityExist', true);
   xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
   xhr.onreadystatechange = this.xhr_doesVideoEntityExist_onreadystatechange.bind(this, xhr, params,
-      videoUuid);
+      videoUuid, failureCount);
   xhr.send(params);
 };
 
 fmltc.UploadVideoFileDialog.prototype.xhr_doesVideoEntityExist_onreadystatechange = function(xhr, params,
-    videoUuid) {
+    videoUuid, failureCount) {
   if (xhr.readyState === 4) {
     xhr.onreadystatechange = null;
 
@@ -246,16 +265,20 @@ fmltc.UploadVideoFileDialog.prototype.xhr_doesVideoEntityExist_onreadystatechang
       if (response.video_entity_exists) {
         this.setState(fmltc.UploadVideoFileDialog.STATE_EXTRACTION_STARTING);
         this.onVideoUploaded(videoUuid);
-        setTimeout(this.dismissButton_onclick.bind(this), 1000);
+        setTimeout(this.closeButton_onclick.bind(this), 1000);
       } else {
-        setTimeout(this.doesVideoEntityExist.bind(this, videoUuid), 5000);
+        setTimeout(this.doesVideoEntityExist.bind(this, videoUuid, 0), 5000);
       }
 
     } else {
-      console.log('Failure! /doesVideoEntityExist?' + params +
-          ' xhr.status is ' + xhr.status + '. xhr.statusText is ' + xhr.statusText);
-      console.log('Will retry /doesVideoEntityExist?' + params + ' in 5 seconds.');
-      setTimeout(this.doesVideoEntityExist.bind(this, videoUuid), 5000);
+      failureCount++;
+      if (failureCount < 5) {
+        const delay = Math.pow(2, failureCount);
+        console.log('Will retry /doesVideoEntityExist?' + params + ' in ' + delay + ' seconds.');
+        setTimeout(this.doesVideoEntityExist.bind(this, videoUuid, failureCount), delay * 1000);
+      } else {
+        this.setState(fmltc.UploadVideoFileDialog.STATE_UPLOADING_MAY_HAVE_FAILED);
+      }
     }
   }
 };

--- a/server/src/js/util.js
+++ b/server/src/js/util.js
@@ -378,9 +378,8 @@ fmltc.Util.prototype.formatJobState = function(jobType, modelEntity) {
 
   if (jobType == 'train' && modelEntity.cancel_requested &&
       jobState != 'CANCELLING' && !this.isJobDone(jobState)) {
-      // The job hasn't responded to our request to cancel it.
-      return 'STOP REQUESTED';
-    }
+    // The job hasn't responded to our request to cancel it.
+    return 'STOP REQUESTED';
   }
 
   if (jobState == 'CANCELLING') {

--- a/server/src/js/util.js
+++ b/server/src/js/util.js
@@ -373,35 +373,42 @@ fmltc.Util.prototype.isStateCancelRequested = function(cancelRequested, jobState
   return cancelRequested && jobState != 'CANCELLING' && !this.isJobDone(jobState);
 };
 
-fmltc.Util.prototype.formatJobState = function(jobType, cancelRequested, jobState) {
-  if (jobType == 'train') {
-    if (cancelRequested && jobState != 'CANCELLING' && !this.isJobDone(jobState)) {
-      return 'CANCEL REQUESTED';
-    }
+fmltc.Util.prototype.formatJobState = function(jobType, modelEntity) {
+  const jobState = (jobType == 'train') ? modelEntity.train_job_state : modelEntity.eval_job_state;
 
-    // If the user didn't request the job to be cancelled, but the state is cancelled, it means that
-    // it was cancelled because it hit the time limit. We show STOPPING/STOPPED.
-    if (!cancelRequested) {
-      if (jobState == 'CANCELLING') {
-        return 'STOPPING';
-      }
-      if (jobState == 'CANCELLED') {
-        return 'STOPPED';
-      }
+  if (jobType == 'train' && modelEntity.cancel_requested &&
+      jobState != 'CANCELLING' && !this.isJobDone(jobState)) {
+      // The job hasn't responded to our request to cancel it.
+      return 'STOP REQUESTED';
     }
+  }
 
-  } else if (jobType == 'eval') {
-    // Because the server (not the user) cancels the eval job when it has completed the last
-    // evaluation, we just show STOPPING/STOPPED.
-    if (jobState == 'CANCELLING') {
-      return 'STOPPING';
-    }
-    if (jobState == 'CANCELLED') {
+  if (jobState == 'CANCELLING') {
+    // Until the job is stopped, we don't know for sure whether there will be a checkpoint or not,
+    // so we show STOPPING.
+    return 'STOPPING';
+  }
+
+  if (jobState == 'CANCELLED') {
+    // We only show CANCELLED if the user cancelled it before any checkpoints were made.
+    if (jobType == 'train' &&
+        modelEntity.cancel_requested &&
+        !this.modelHasCheckpoint(modelEntity)) {
+      return 'CANCELLED';
+    } else {
       return 'STOPPED';
     }
   }
 
   return jobState;
+};
+
+fmltc.Util.prototype.modelHasCheckpoint = function(modelEntity) {
+  return modelEntity.trained_checkpoint_path != '' && this.isModelTensorFlow2(modelEntity);
+};
+
+fmltc.Util.prototype.isModelTensorFlow2 = function(modelEntity) {
+  return 'tensorflow_version' in modelEntity && modelEntity.tensorflow_version != '2';
 };
 
 fmltc.Util.prototype.sortedLabelListsEqual = function(a1, a2) {

--- a/server/storage.py
+++ b/server/storage.py
@@ -1225,7 +1225,7 @@ def model_trainer_started(team_uuid, model_uuid, description, model_folder,
         transaction.put(model_entity)
         return model_entity
 
-def cancel_training_requested(team_uuid, model_uuid):
+def stop_training_requested(team_uuid, model_uuid):
     datastore_client = datastore.Client()
     with datastore_client.transaction() as transaction:
         model_entity = retrieve_model_entity(team_uuid, model_uuid)

--- a/server/templates/labelVideo.html
+++ b/server/templates/labelVideo.html
@@ -77,7 +77,7 @@ limitations under the License.
             <tr>
               <td valign="top">
                 <table style="width: 100%"><tr>
-                  <td><button id="dismissButton" class="btn btn-primary">Back</button></td>
+                  <td><button id="backButton" class="btn btn-primary">Back</button></td>
                   <td style="width: 100%"><span id="descriptionSpan" class="h3 text-center d-block"></span></td>
                   <td><button id="smallerImageButton" title="Smaller" disabled="true"
                     class="btn btn-primary material-icons">zoom_out</button></td>

--- a/server/templates/monitorTraining.html
+++ b/server/templates/monitorTraining.html
@@ -31,12 +31,12 @@ limitations under the License.
 <body>
 
 <table style="width: 100%"><tr>
-  <td style="width: 40px"><button id="dismissButton" class="material-icons iconVerticalAlign text-24">close</button></td>
+  <td style="width: 40px"><button id="backButton" class="material-icons iconVerticalAlign text-24">close</button></td>
   <td><span id="descriptionSpan" class="text-24"></span></td>
   <td align="right">
     <div id="activeTrainingDiv" style="display: none;">
-      <button id="cancelTrainingButton" class="text-24">
-        <span class="material-icons iconVerticalAlign">cancel</span><span class="iconVerticalAlign">Cancel Training</span>
+      <button id="stopTrainingButton" class="text-24">
+        <span class="material-icons iconVerticalAlign">cancel</span><span class="iconVerticalAlign">Stop Training</span>
       </button>
       <label for="refreshIntervalRangeInput" class="text-18">Refresh Interval:</label>
       <input type="range" id="refreshIntervalRangeInput" name="refreshIntervalRangeInput" min="1" value="5" max="15">

--- a/server/templates/root.html
+++ b/server/templates/root.html
@@ -232,9 +232,9 @@ limitations under the License.
                         </td>
                         <td width="10px"></td>
                         <td align="center" valign="top">
-                          <button id="cancelTrainingButton" class="btn btn-secondary">
+                          <button id="stopTrainingButton" class="btn btn-secondary">
                             <span class="material-icons iconVerticalAlign">cancel</span>
-                            <span class="iconVerticalAlign">Cancel Training</span>
+                            <span class="iconVerticalAlign">Stop Training</span>
                           </button>
                         </td>
                         <td width="10px"></td>
@@ -280,7 +280,7 @@ limitations under the License.
           <div class="modal-content">
             <div class="modal-header">
               <h5 class="modal-title" id="exampleModalLabel">Upload Video File</h5>
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" id="uvfXButton"></button>
             </div>
             <div class="modal-body">
               <input type="file" id="uvfVideoFileInput" accept="video/*" class="text-18" style="width: 100%">
@@ -289,15 +289,15 @@ limitations under the License.
               <input type="text" maxlength="30" id="uvfDescriptionInput" class="form-control" style="width: 100%">
               <br><br>
               <button id="uvfUploadButton" class="btn btn-secondary" >Upload</button>
-              <h3 id="uvfUploadingH3" style="visibility: hidden;">Uploading Progress</h3>
               <div id="uvfUploadingState"></div>
-              <div><progress id="uvfUploadingProgress" style="visibility: hidden;"></progress></div>
+              <h4 id="uvfUploadingProgressHeader" style="display: none;">Uploading Progress</h4>
+              <div><progress id="uvfUploadingProgress" style="display: none;"></progress></div>
               <div id="uvfUploadingFailedDiv" class="text-24" style="display: none;">
                 Uploading has failed!
               </div>
             </div>
             <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" id="uvfDismissButton">Close</button>
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" id="uvfCloseButton">Close</button>
             </div>
           </div>
         </div>
@@ -308,7 +308,7 @@ limitations under the License.
           <div class="modal-content">
             <div class="modal-header">
               <h5 class="modal-title" id="exampleModalLabel">Produce Dataset</h5>
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" id="pdXButton"></button>
             </div>
             <div class="modal-body">
               <table class="text-18">
@@ -343,7 +343,7 @@ limitations under the License.
               <div id="pdFailedDiv" class="text-24" style="display: none;">Failed!</div>
             </div>
             <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" id="pdDismissButton">Close</button>
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" id="pdCloseButton">Close</button>
             </div>            
           </div>
         </div>
@@ -354,7 +354,7 @@ limitations under the License.
           <div class="modal-content">
             <div class="modal-header">
               <h5 id="dcTitleDiv" class="modal-title"></h5>
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" id="dcXButton"></button>
             </div>
             <div class="modal-body">
               <center>          
@@ -376,7 +376,7 @@ limitations under the License.
           <div class="modal-content">
             <div class="modal-header">
               <h5 id="dfTitleDiv" class="modal-title"></h5>
-              <button type="button" id="dfDismissButton" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" id="dfXButton"></button>
             </div>
             <div class="modal-body">
               <div id="dfMessageDiv" class="text-20"></div>
@@ -396,7 +396,7 @@ limitations under the License.
           <div class="modal-content">
             <div class="modal-header">
               <h5 class="modal-title">Download Dataset</h5>
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" id="ddXButton"></button>
             </div>
             <div class="modal-body">
                 <div>
@@ -416,7 +416,7 @@ limitations under the License.
                 <div id="ddFinishedDiv" class="text-24" style="visibility: hidden;">Finished.</div>
             </div>
             <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" id="ddDismissButton">Close</button>
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" id="ddCloseButton">Close</button>
             </div>
           </div>
         </div>
@@ -427,7 +427,7 @@ limitations under the License.
           <div class="modal-content">
             <div class="modal-header">
               <h5 class="modal-title">Start Training</h5>
-              <button type="button" id="stDismissButton" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" id="stXButton"></button>
             </div>
             <div class="modal-body">
               <div class="text-18">
@@ -477,7 +477,7 @@ limitations under the License.
               <div id="stFailedDiv" style="display: none;">Failed!</div>
             </div>
             <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" id="stDismissButton">Close</button>
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" id="stCloseButton">Close</button>
             </div>
           </div>
         </div>
@@ -488,7 +488,7 @@ limitations under the License.
           <div class="modal-content">
             <div class="modal-header">
               <h5 class="modal-title">Train More</h5>
-              <button type="button" id="tmDismissButton" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" id="tmXButton"></button>
             </div>
             <div class="modal-body">
               <div class="text-18">
@@ -533,7 +533,7 @@ limitations under the License.
               <div id="tmFailedDiv" style="display: none;">Failed!</div>
             </div>
             <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" id="tmDismissButton">Close</button>
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" id="tmCloseButton">Close</button>
             </div>
           </div>
         </div>
@@ -544,7 +544,7 @@ limitations under the License.
           <div class="modal-content">
             <div class="modal-header">
               <h5 class="modal-title">Download Model</h5>
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" id="dmXButton"></button>
             </div>
             <div class="modal-body">
               <div>
@@ -552,7 +552,7 @@ limitations under the License.
               </div>
             </div>
             <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" id="dmDismissButton">Close</button>
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" id="dmCloseButton">Close</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Fixes #119 
In dialogs, added an id to all X buttons and changed ids for Close buttons from DismissButton to CloseButton
Renamed dismissButton to backButton in label video code.
Renamed dismissButton to backButton in monitor trainingcode.
Updated javascript to properly enable/disable X and Close buttons.

In upload video dialog, improved error message for when the /prepareToUploadVideo has invalid parameters.
If the /prepareToUploadVideo has an error, allow the user to choose a different file.

Only retry failing requests 5 times. This was already done for most requests, but here I've added it for the following:
/retrieveModelEntity
/retrieveDatasetEntity
/prepareToUploadVideo
/doesVideoEntityExist

When training a model, change Cancel Training to Stop Training.
Show STOP REQUESTED instead of CANCEL REQUESTED.
Show STOPPING instead of CANCELLING.
Show STOPPED instead of CANCELLED the training job created any checkpoints.