### PR TITLE
Fixed problem where the training monitor cloud function dies if it can't update the job state in the model entity

### DIFF
--- a/server/frame_extractor.py
+++ b/server/frame_extractor.py
@@ -60,6 +60,7 @@ def wait_for_video_upload(action_parameters):
         if blob_storage.video_blob_exists(team_uuid, video_uuid):
             video_entity = storage.create_video_entity(
                 team_uuid, video_uuid, description, video_filename, file_size, content_type, create_time_ms)
+            storage.prepare_to_start_frame_extraction(team_uuid, video_uuid)
             __start_frame_extraction(video_entity)
             return
         # Note that we don't retrigger this action. If the video isn't there by now, it's probably


### PR DESCRIPTION
In model_trainer.__update_model_entity_job_state, put try catch around storage.update_model_entity_job_state so that monitor training cloud function doesn't die if it can't update the job states in the model entity.

Fixed model_trainer.maybe_restart_monitor_training which was incorrectly returning false if the triggered time was non-zero.

Added code to ListModels.onModelEntityUpdated to send /maybeRestartMonitorTraining if necessary.

Fixed ListModels.prototype.updateButtons which was incorrectly disabling the More Training and Download Model buttons.