### PR TITLE
Prevent creating datasets with no labeled frames

### DIFF
--- a/server/app_engine.py
+++ b/server/app_engine.py
@@ -827,7 +827,7 @@ def prepare_to_start_dataset_production():
     eval_percent = validate_float(data.get('eval_percent'), min=0, max=90)
     create_time_ms = validate_create_time_ms(data.get('create_time_ms'))
     # dataset_producer.prepare_to_start_dataset_production will raise HttpErrorNotFound
-    # if any of the team_uuid/video_uuids is not found.
+    # if any of the team_uuid/video_uuids is not found or if none of the videos have labeled frames.
     dataset_uuid = dataset_producer.prepare_to_start_dataset_production(
         team_uuid, description, video_uuids_json, eval_percent, create_time_ms)
     action_parameters = dataset_producer.make_action_parameters(

--- a/server/dataset_producer.py
+++ b/server/dataset_producer.py
@@ -53,7 +53,7 @@ FrameData = collections.namedtuple('FrameData', [
 
 def prepare_to_start_dataset_production(team_uuid, description, video_uuids_json, eval_percent, create_time_ms):
     # storage.prepare_to_start_dataset_production will raise HttpErrorNotFound
-    # if any of the team_uuid/video_uuids is not found.
+    # if any of the team_uuid/video_uuids is not found or if none of the videos have labeled frames.
     dataset_uuid = storage.prepare_to_start_dataset_production(team_uuid, description,
         json.loads(video_uuids_json), eval_percent, create_time_ms)
     return dataset_uuid

--- a/server/src/js/listVideos.js
+++ b/server/src/js/listVideos.js
@@ -313,16 +313,19 @@ fmltc.ListVideos.prototype.checkbox_onclick = function() {
 
 fmltc.ListVideos.prototype.updateButtons = function() {
   let countChecked = 0;
-  let countCanProduceDataset = 0;
+  let countFrameExtractionComplete = 0;
+  let totalLabeledFrameCount = 0
   for (let i = 0; i < this.checkboxes.length; i++) {
     if (this.checkboxes[i].checked) {
       countChecked++;
       if (!this.frameExtractionFailed[i] && this.frameExtractionComplete[i]) {
-        countCanProduceDataset++;
+        countFrameExtractionComplete++;
+        totalLabeledFrameCount += this.videoEntityArray[i].labeled_frame_count;
       }
     }
   }
-  this.produceDatasetButton.disabled = this.waitCursor || countChecked == 0 || countCanProduceDataset != countChecked;
+  this.produceDatasetButton.disabled = this.waitCursor || countChecked == 0 ||
+      countFrameExtractionComplete != countChecked || totalLabeledFrameCount == 0;
   this.deleteVideosButton.disabled = this.waitCursor || countChecked == 0;
 };
 


### PR DESCRIPTION
Disable the Produce Dataset button if none of the checked videos have labeled frames.

In the /prepareToStartDatasetProduction request handler, raise HttpErrorNotFound if none of the specified videos have labeled frames.