### PR TITLE
Added limits related to the video files we support

### DIFF
--- a/server/app_engine.py
+++ b/server/app_engine.py
@@ -18,7 +18,9 @@ __author__ = "lizlooney@google.com (Liz Looney)"
 from datetime import datetime, timedelta, timezone
 import json
 import logging
+import math
 import time
+import traceback
 
 # Other Modules
 import flask
@@ -233,12 +235,9 @@ def validate_create_time_ms(s):
     i = validate_positive_int(s)
     create_time = util.datetime_from_ms(i)
     now = datetime.now(timezone.utc)
-    delta = now - create_time
-    if delta < timedelta(seconds=0):
-        message = "Error: '%s is not a valid create time." % s
-        logging.critical(message)
-        raise exceptions.HttpErrorBadRequest(message)
-    if delta > timedelta(minutes=1):
+    delta_seconds = math.fabs((now - create_time).total_seconds())
+    # Allow a 3 minute difference between the user's clock and the server's clock.
+    if delta_seconds > 3 * 60:
         message = "Error: '%s is not a valid create time." % s
         logging.critical(message)
         raise exceptions.HttpErrorBadRequest(message)
@@ -471,6 +470,16 @@ def prepare_to_upload_video():
     video_filename = data.get('video_filename')
     try:
         file_size = validate_positive_int(data.get('file_size'))
+        # Don't allow videos that are larger than 100 MB.
+        # The value 100 * 1000 * 1000 should match the value used in uploadVideoFileDialog.js.
+        if file_size > 100 * 1000 * 1000:
+            # Send a message to the client.
+            response = {
+                'video_uuid': '',
+                'upload_url': '',
+                'message': 'The file is larger than 100 MB, which is the maximum size allowed.'
+            }
+            return flask.jsonify(response)
     except exceptions.HttpErrorBadRequest:
         # Send a message to the client.
         response = {
@@ -1079,7 +1088,7 @@ def retrieve_summary_items():
         step_key = 'step' + str(i)
         tag_key = 'tag' + str(i)
         if step_key not in data or tag_key not in data:
-            break;
+            break
         step = data[step_key]
         if step not in dict_step_to_tags:
             dict_step_to_tags[step] = []
@@ -1263,11 +1272,15 @@ def add_userinfo_breadcrumb():
 def capture_exception(e):
     if sentry_dsn is not None:
         sentry_sdk.capture_exception(e)
+    else:
+        util.log('capture_exception traceback: %s' % traceback.format_exc().replace('\n', ' ... '))
 
 
 def capture_message(e):
     if sentry_dsn is not None:
         sentry_sdk.capture_message(message=e)
+    else:
+        util.log('capture_message message: %s' % str(e))
 
 
 @app.errorhandler(403)

--- a/server/static/css/styles.css
+++ b/server/static/css/styles.css
@@ -218,3 +218,29 @@ body {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
+
+/* Tooltips */
+
+.hasTooltip {
+  position: relative;
+  display: inline-block;
+  border-bottom: 1px dotted black;
+}
+
+.hasTooltip .isTooltipText {
+  visibility: hidden;
+  width: 300px;
+  background-color: #FFDEAD;
+  color: black;
+  border-radius: 6px;
+  padding: 0 10px;
+  margin-left: 5px;
+
+  /* Position the tooltip */
+  position: absolute;
+  z-index: 1;
+}
+
+.hasTooltip:hover .isTooltipText {
+  visibility: visible;
+}

--- a/server/storage.py
+++ b/server/storage.py
@@ -234,12 +234,19 @@ def frame_extraction_done(team_uuid, video_uuid, frame_count):
         return video_entity
 
 
-def frame_extraction_failed(team_uuid, video_uuid):
+def frame_extraction_failed(team_uuid, video_uuid, error_message, width=None, height=None, fps=None, frame_count=0):
     datastore_client = datastore.Client()
     with datastore_client.transaction() as transaction:
         video_entity = retrieve_video_entity(team_uuid, video_uuid)
         video_entity['frame_extraction_failed'] = True
-        video_entity['frame_count'] = 0
+        video_entity['frame_extraction_error_message'] = error_message
+        if width is not None:
+            video_entity['width'] = width
+        if height is not None:
+            video_entity['height'] = height
+        if fps is not None:
+            video_entity['fps'] = fps
+        video_entity['frame_count'] = frame_count
         video_entity['frame_extraction_end_time'] = datetime.now(timezone.utc)
         video_entity['frame_extraction_active_time'] = video_entity['frame_extraction_end_time']
         video_entity['frame_extraction_active_time_ms'] = util.ms_from_datetime(video_entity['frame_extraction_active_time'])


### PR DESCRIPTION
When validating createTimeMs parameters, allow the difference between user and server clocks to be up to 3 minutes.

Don't allow user to upload a video larger than 100 MB or longer than 2 minutes.

If frame extraction fails save an error message in the video entity and display it in a tooltip in the UI.
If the video has more than 1000 frames or resolution larger than 3840 x 2160, show that in a tooltip and don't extract frame.