### PR TITLE
Add support for filtering on a list of closed beta teams

### DIFF
--- a/server/app_engine.py
+++ b/server/app_engine.py
@@ -357,7 +357,7 @@ def submit_team():
         flask.session['team_number'] = team_num
         flask.session['name'] = given_name
 
-        roles.can_login(flask.session['user_roles'])
+        roles.can_login(flask.session['user_roles'], team_num)
 
         return flask.redirect(flask.url_for('index'))
     else:
@@ -387,7 +387,7 @@ def login():
 @handle_exceptions
 @redirect_to_login_if_needed
 def index():
-    roles.can_login(flask.session['user_roles'])
+    roles.can_login(flask.session['user_roles'], flask.session['team_number'])
 
     team_uuid = team_info.retrieve_team_uuid(flask.session, flask.request)
     program, team_number = team_info.retrieve_program_and_team_number(flask.session)

--- a/server/team_info.py
+++ b/server/team_info.py
@@ -61,7 +61,7 @@ def __validate_team_oidc(session):
     #
     user_roles = session.get('user_roles')
     if user_roles:
-        roles.can_login(session['user_roles'])
+        roles.can_login(session['user_roles'], session['team_number'])
         return True
     else:
         return False
@@ -77,7 +77,7 @@ def __validate_team_local(session):
 
 def __validate_team_info(program, team_number, team_code):
     bucket = util.storage_client().get_bucket(BUCKET_BLOBS)
-    teams = bucket.blob('team_info/teams').download_as_string().decode('utf-8')
+    teams = bucket.blob('team_info/teams').download_as_bytes().decode('utf-8')
     for line in teams.split('\n'):
         line = line.strip()
         if line == "":


### PR DESCRIPTION
If a simple list of teams exists in a specific bucket, then assign all of those teams the ml_test role.

Only applies to the production environment.  The ml_test role was removed from the development environment to prevent teams from being able to log into both.

@lizlooney The team_info download_as_bytes() change is just because the documentation for download_as_string() says it's deprecated and the implementation just calls download_as_bytes().