### PR TITLE
Rudimentary support for announcements

### DIFF
--- a/server/announcements.py
+++ b/server/announcements.py
@@ -1,0 +1,40 @@
+# Copyright 2021 FIRST
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+from google.cloud import datastore
+
+DS_ANNOUNCEMENT = 'Announcements'
+
+
+#
+# Returns a list of announcement entities
+#
+def get_announcements():
+    datastore_client = datastore.Client()
+    query = datastore_client.query(kind=DS_ANNOUNCEMENT)
+    return list(query.fetch())
+
+
+#
+# Could this be done with an indexed query?  Perhaps, but despite all the documentation
+# from Google, built in indexes don't seem to be supported when using Firestore in datastore mode.
+# And it seems silly to create a single property index when all the Google documentation says
+# single property indexes already exist.  So, this is just easier than fighting the datastore api.
+#
+def get_unexpired_announcements():
+    elems = get_announcements()
+    announcements = list(filter(lambda a: a['expires'].replace(tzinfo=None) > datetime.now(), elems))
+    return announcements
+

--- a/server/app_engine.py
+++ b/server/app_engine.py
@@ -31,6 +31,7 @@ from werkzeug.exceptions import Forbidden
 
 # My Modules
 import action
+import announcements
 import bbox_writer
 import blob_storage
 import cloud_secrets
@@ -122,7 +123,8 @@ application_properties = json.load(open('app.properties', 'r'))
 def inject_time():
     program, team_number = team_info.retrieve_program_and_team_number(flask.session)
     return dict(time_time=time.time(), project_id=constants.PROJECT_ID, name=flask.session.get('given_name'),
-                program=program, team_number=team_number, version=application_properties.get('version'))
+                program=program, team_number=team_number, version=application_properties.get('version'),
+                announcements=announcements.get_unexpired_announcements())
 
 
 def validate_keys(dict, expected_keys, check_all_keys=True, optional_keys=[]):

--- a/server/templates/layout.html
+++ b/server/templates/layout.html
@@ -47,6 +47,22 @@ limitations under the License.
                 </div>
             </div>
         </nav>
+        <div id="announcementContainer">
+        {% if announcements|length > 0 %}
+          {% for ann in announcements %}
+            <div class="card border-info mb-3" style="margin: 0.5rem;">
+                <div class="card-body" style="padding: 0.75rem;">
+                    <h5 class="card-title">
+                        <span>{{ann['title']}}</span>
+                    </h5>
+                    <div>
+                        <p>{{ann['description']}}<br></p>
+                    </div>
+               </div>
+            </div>
+            {% endfor %}
+        {% endif %}
+        </div>
         <hr class="onlyOnFull">
 
         {% block content %}{% endblock %}

--- a/server/templates/test.html
+++ b/server/templates/test.html
@@ -28,6 +28,11 @@ Use OIDC: {{use_oidc}}
 <br><br>
 Redis IP: {{redis_ip}}
 <br><br>
+{% for ann in announcements %}
+<br><br>
+{{ ann['description'] }}
+{% endfor %}
+<br><br>
 <script type="text/javascript">
   window.addEventListener('load', function() {
     const sendPerformActionGCF = document.getElementById('sendPerformActionGCF');

--- a/server/test_routes.py
+++ b/server/test_routes.py
@@ -17,6 +17,7 @@ import time
 import flask
 from flask import Blueprint
 
+import announcements
 import constants
 import exceptions
 import oidc
@@ -44,4 +45,13 @@ def testExcept():
     if util.is_production_env():
         raise exceptions.HttpErrorNotFound("Not found")
     raise ArithmeticError("Exception Test")
+
+
+@test_routes.route('/testAnnouncements')
+@handle_exceptions
+@redirect_to_login_if_needed
+def testAnnouncements():
+    ann = announcements.get_unexpired_announcements()
+    return flask.render_template('test.html', time_time=time.time(), project_id=constants.PROJECT_ID,
+                                 use_oidc=oidc.is_using_oidc(), redis_ip=constants.REDIS_IP_ADDR, announcements=ann)
 


### PR DESCRIPTION
This is not designed to be all comprehensive.  e.g.  There's no admin UI, no role selection, no dismissal.  Just a quick implementation of a static announcement banner.

Announcements are stored in datastore in an Announcements collection.  Support for expiration dates is provided.

To add an announcement:
 - Go to the Google Cloud Datastore console
 - If an Announcements collection doesn't already exist, create one called 'Announcements'.
 - Create a document
 - Add three fields, 'title' of type string, 'description' of type string, and 'expires' of type timestamp.

Multiple announcements are supported.   An admin can make an announcement go away by simply editing the expires field to be in the past.
  