### PR TITLE
Configurable secure session cookies

### DIFF
--- a/server/app_engine.py
+++ b/server/app_engine.py
@@ -91,7 +91,7 @@ app.config.update(
         # For SESSION_COOKIE_SAMESITE, Strict means that cookies will only be sent in a first-party
         # context and not be sent along with requests initiated by third party websites.
         # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#values
-        "SESSION_COOKIE_SAMESITE": "Strict" if config.get_secure_session_cookies() else "Lax",
+        "SESSION_COOKIE_SAMESITE": "Strict" if config.get_samesite_session_cookies() else "Lax",
 
         # OIDC properties
 

--- a/server/config.py
+++ b/server/config.py
@@ -24,6 +24,7 @@ DS_SERVER_CONFIG = "Configuration"
 KEY_TRAINING_ENABLED = 'training_enabled'
 KEY_USE_TPU = 'use_tpu'
 KEY_SECURE_SESSION_COOKIES = 'secure_session_cookies'
+KEY_SAMESITE_SESSION_COOKIES = 'samesite_session_cookies'
 
 
 #
@@ -35,10 +36,13 @@ class Config:
     training_enabled = True
     use_tpu = True
     secure_session_cookies = True
+    samesite_session_cookies = True
 
     def reset(self):
         self.training_enabled = True
         self.use_tpu = True
+        self.secure_session_cookies = True
+        self.samesite_session_cookies = True
 
     def refresh(self):
         client = datastore.Client()
@@ -67,6 +71,11 @@ class Config:
         else:
             self.secure_session_cookies = True
 
+        if KEY_SAMESITE_SESSION_COOKIES in entity:
+            self.samesite_session_cookies = entity[KEY_SAMESITE_SESSION_COOKIES]
+        else:
+            self.samesite_session_cookies = True
+
     def get_training_enabled(self):
         return self.training_enabled
 
@@ -83,4 +92,7 @@ class Config:
 
     def get_secure_session_cookies(self):
         return self.secure_session_cookies
+
+    def get_samesite_session_cookies(self):
+        return self.samesite_session_cookies
 


### PR DESCRIPTION
Add a config item to allow for turning off secure session cookies.  We leave secure cookies on by default.  This fixes oidc login on local development environments that are running on 127.0.0.1 that would otherwise run into CSRF token denials caused by #156 