### PR TITLE
Prevent CORS failure on frame 0

### DIFF
--- a/server/app_engine.py
+++ b/server/app_engine.py
@@ -430,6 +430,7 @@ def label_video():
     video_entity = storage.retrieve_video_entity_for_labeling(team_uuid, video_uuid)
     video_frame_entity_0 = storage.retrieve_video_frame_entities_with_image_urls(
         team_uuid, video_uuid, 0, 0)[0]
+    blob_storage.set_cors_policy_for_get()
     sanitize(video_entity)
     sanitize(video_frame_entity_0)
     return flask.render_template('labelVideo.html',

--- a/server/src/js/labelVideo.js
+++ b/server/src/js/labelVideo.js
@@ -571,9 +571,11 @@ fmltc.LabelVideo.prototype.xhr_retrieveVideoFrameImage_onreadystatechange = func
 
     } else {
       failureCount++;
-      if (failureCount < 2) {
+      if (failureCount < 5) {
         const delay = Math.pow(2, failureCount);
-        console.log('Will retry ' + imageUrl + ' in ' + delay + ' seconds.');
+        console.log('Error occurred when retrieving the image for frame ' + frameNumber + '.\n' +
+            'xhr.status is ' + xhr.status + '.\n' +
+            'Will retry ' + imageUrl + ' in ' + delay + ' seconds.');
         setTimeout(this.retrieveVideoFrameImage.bind(this, frameNumber, imageUrl, failureCount), delay * 1000);
       } else {
         this.loadFailure();


### PR DESCRIPTION
Call blob_storage.set_cors_policy_for_get() in label_video() because the URL for frame 0 is returned with the html response.