### PR TITLE
Admin page in header, and configuration data on admin page.

### DIFF
--- a/server/app_engine.py
+++ b/server/app_engine.py
@@ -128,7 +128,8 @@ application_properties = json.load(open('app.properties', 'r'))
 def inject_time():
     program, team_number = team_info.retrieve_program_and_team_number(flask.session)
     return dict(time_time=time.time(), project_id=constants.PROJECT_ID, name=flask.session.get('given_name'),
-                program=program, team_number=team_number, version=application_properties.get('version'),
+                program=program, team_number=team_number, is_admin=roles.is_global_admin(flask.session.get('user_roles')),
+                version=application_properties.get('version'),
                 announcements=announcements.get_unexpired_announcements())
 
 

--- a/server/app_engine.py
+++ b/server/app_engine.py
@@ -131,8 +131,12 @@ application_properties = json.load(open('app.properties', 'r'))
 @app.context_processor
 def inject_time():
     program, team_number = team_info.retrieve_program_and_team_number(flask.session)
+    if 'user_roles' in flask.session:
+        is_admin = roles.is_global_admin(flask.session.get('user_roles'))
+    else:
+        is_admin = False
     return dict(time_time=time.time(), project_id=constants.PROJECT_ID, name=flask.session.get('given_name'),
-                program=program, team_number=team_number, is_admin=roles.is_global_admin(flask.session.get('user_roles')),
+                program=program, team_number=team_number, is_admin=is_admin,
                 version=application_properties.get('version'),
                 announcements=announcements.get_unexpired_announcements())
 

--- a/server/app_engine.py
+++ b/server/app_engine.py
@@ -46,6 +46,10 @@ import oidc
 import roles
 from roles import Role
 from config import Config
+from config import KEY_TRAINING_ENABLED
+from config import KEY_USE_TPU
+from config import KEY_SECURE_SESSION_COOKIES
+from config import KEY_SAMESITE_SESSION_COOKIES
 import storage
 import team_info
 import test_routes
@@ -87,12 +91,12 @@ app.config.update(
         # For SESSION_COOKIE_SECURE, True means that cookies will only be sent to the server with an
         # encrypted request over the HTTPS protocol.
         # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#restrict_access_to_cookies
-        "SESSION_COOKIE_SECURE": config.get_secure_session_cookies(),
+        "SESSION_COOKIE_SECURE": config[KEY_SECURE_SESSION_COOKIES],
 
         # For SESSION_COOKIE_SAMESITE, Strict means that cookies will only be sent in a first-party
         # context and not be sent along with requests initiated by third party websites.
         # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#values
-        "SESSION_COOKIE_SAMESITE": "Strict" if config.get_samesite_session_cookies() else "Lax",
+        "SESSION_COOKIE_SAMESITE": "Strict" if config[KEY_SAMESITE_SESSION_COOKIES] else "Lax",
 
         # OIDC properties
 
@@ -414,7 +418,7 @@ def index():
         can_upload_video=roles.can_upload_video(flask.session['user_roles']),
         training_enabled=config.get_training_enabled_as_str(),
         team_preferences=storage.retrieve_user_preferences(team_uuid),
-        model_trainer_data=model_trainer.get_data_for_root_template(config.get_use_tpu()))
+        model_trainer_data=model_trainer.get_data_for_root_template(config[KEY_USE_TPU]))
 
 @app.route('/labelVideo')
 @handle_exceptions
@@ -460,12 +464,26 @@ def monitor_training():
         dataset_entities_by_uuid=dataset_entities_by_uuid,
         video_entities_by_uuid=video_entities_by_uuid)
 
+
 @app.route('/admin', methods=['GET'])
 @handle_exceptions
 @login_required
 @roles_accepted(roles.Role.GLOBAL_ADMIN, roles.Role.ML_DEVELOPER)
 def admin():
-    return flask.render_template('admin.html')
+    return flask.render_template('admin.html', config=config)
+
+
+@app.route('/refreshConfig', methods=['POST'])
+@handle_exceptions
+@login_required
+@roles_accepted(roles.Role.GLOBAL_ADMIN, roles.Role.ML_DEVELOPER)
+def refresh_config():
+    config.refresh()
+    app.config.update({
+        "SESSION_COOKIE_SECURE": config[KEY_SECURE_SESSION_COOKIES],
+        "SESSION_COOKIE_SAMESITE": "Strict" if config[KEY_SAMESITE_SESSION_COOKIES] else "Lax",
+    })
+    return flask.jsonify(config)
 
 
 # requests
@@ -1106,7 +1124,7 @@ def delete_dataset_zip():
 @handle_exceptions
 @login_required
 def start_training_model():
-    if not config.get_training_enabled():
+    if not config[KEY_TRAINING_ENABLED]:
         raise Forbidden
     team_uuid = team_info.retrieve_team_uuid(flask.session, flask.request)
     data = validate_keys(flask.request.form.to_dict(flat=True),
@@ -1119,8 +1137,8 @@ def start_training_model():
     starting_model = model_trainer.validate_starting_model(data.get('starting_model'))
     max_running_minutes = validate_positive_float(data.get('max_running_minutes'))
     num_training_steps = validate_int(data.get('num_training_steps'),
-        min=model_trainer.get_min_training_steps(config.get_use_tpu()),
-        max=model_trainer.get_max_training_steps(config.get_use_tpu()))
+        min=model_trainer.get_min_training_steps(config[KEY_USE_TPU]),
+        max=model_trainer.get_max_training_steps(config[KEY_USE_TPU]))
     create_time_ms = validate_create_time_ms(data.get('create_time_ms'))
     # model_trainer.start_training_model will raise HttpErrorNotFound
     # if starting_model is not a valid starting model and it's not a valid model_uuid, or
@@ -1130,7 +1148,7 @@ def start_training_model():
     # model_trainer.start_training_model will raise HttpErrorUnprocessableEntity
     # if the max_running_minutes exceeds the team's remaining_training_minutes.
     model_entity = model_trainer.start_training_model(team_uuid, description, dataset_uuids_json,
-        starting_model, max_running_minutes, num_training_steps, create_time_ms, config.get_use_tpu())
+        starting_model, max_running_minutes, num_training_steps, create_time_ms, config[KEY_USE_TPU])
     # Retrieve the team entity so the client gets the updated remaining_training_minutes.
     team_entity = storage.retrieve_team_entity(team_uuid)
     strip_model_entity(model_entity)

--- a/server/config.py
+++ b/server/config.py
@@ -101,5 +101,5 @@ class Config(dict):
     # not recognize.
     #
     def get_training_enabled_as_str(self):
-        return str(self.training_enabled).lower()
+        return str(self[KEY_TRAINING_ENABLED]).lower()
 

--- a/server/src/js/admin.js
+++ b/server/src/js/admin.js
@@ -44,6 +44,13 @@ fmltc.Admin = function() {
   this.incrementInput.onchange = this.incrementInput_onchange.bind(this);
   this.incrementButton.onclick = this.incrementButton_onclick.bind(this);
 
+  this.trainingEnabled = document.getElementById('trainingEnabled');
+  this.useTpu = document.getElementById('useTpu');
+  this.secureSessionCookies = document.getElementById('secureSessionCookies');
+  this.samesiteSessionCookies = document.getElementById('samesiteSessionCookies');
+  this.refreshConfigButton = document.getElementById('refreshConfigButton');
+  this.refreshConfigButton.onclick = this.refreshConfigButton_onclick.bind(this);
+
   this.enableInputsAndButtons(true);
 };
 
@@ -52,6 +59,7 @@ fmltc.Admin.prototype.enableInputsAndButtons = function(enable) {
   this.resetButton.disabled = !enable;
   this.incrementInput.disabled = !enable;
   this.incrementButton.disabled = !enable;
+  this.refreshConfigButton.disables = !enable;
 };
 
 fmltc.Admin.prototype.resetInput_onchange = function() {
@@ -115,3 +123,30 @@ fmltc.Admin.prototype.xhr_incrementRemainingTrainingMinutes_onreadystatechange =
     }
   }
 };
+
+fmltc.Admin.prototype.refreshConfigButton_onclick = function() {
+  const xhr = new XMLHttpRequest();
+  xhr.open('POST', '/refreshConfig', true);
+  xhr.onreadystatechange = this.xhr_refreshConfigButton_onreadystatechange.bind(this, xhr);
+  xhr.send();
+};
+
+fmltc.Admin.prototype.capitalize = function(str) {
+  return str.charAt(0).toUpperCase() + str.slice(1)
+}
+
+fmltc.Admin.prototype.xhr_refreshConfigButton_onreadystatechange = function(xhr, params) {
+  if (xhr.readyState === 4) {
+    xhr.onreadystatechange = null;
+
+    if (xhr.status === 200) {
+      const response = JSON.parse(xhr.responseText);
+      this.trainingEnabled.textContent = this.capitalize(response.training_enabled.toString());
+      this.useTpu.textContent = this.capitalize(response.use_tpu.toString());
+      this.secureSessionCookies.textContent = this.capitalize(response.secure_session_cookies.toString());
+      this.samesiteSessionCookies.textContent = this.capitalize(response.samesite_session_cookies.toString());
+
+    }
+  }
+};
+

--- a/server/src/js/admin.js
+++ b/server/src/js/admin.js
@@ -127,7 +127,7 @@ fmltc.Admin.prototype.xhr_incrementRemainingTrainingMinutes_onreadystatechange =
 fmltc.Admin.prototype.refreshConfigButton_onclick = function() {
   const xhr = new XMLHttpRequest();
   xhr.open('POST', '/refreshConfig', true);
-  xhr.onreadystatechange = this.xhr_refreshConfigButton_onreadystatechange.bind(this, xhr);
+  xhr.onreadystatechange = this.xhr_refreshConfig_onreadystatechange.bind(this, xhr);
   xhr.send();
 };
 
@@ -135,7 +135,7 @@ fmltc.Admin.prototype.capitalize = function(str) {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }
 
-fmltc.Admin.prototype.xhr_refreshConfigButton_onreadystatechange = function(xhr, params) {
+fmltc.Admin.prototype.xhr_refreshConfig_onreadystatechange = function(xhr, params) {
   if (xhr.readyState === 4) {
     xhr.onreadystatechange = null;
 

--- a/server/templates/admin.html
+++ b/server/templates/admin.html
@@ -64,7 +64,7 @@ limitations under the License.
       <div>Use TPU: <span id="useTpu">{{config['use_tpu']}}</span></div>
       <div>Secure Session Cookies: <span id="secureSessionCookies">{{config['secure_session_cookies']}}</span></div>
       <div>Samesite Session Cookies: <span id="samesiteSessionCookies">{{config['samesite_session_cookies']}}</span></div>
-      <button id="refreshConfigButton" class="btn btn-secondary">Refresh</button>
+      <button id="refreshConfigButton" class="btn btn-secondary">Refresh Cache</button>
       <br><hr><br>
   </div>
 

--- a/server/templates/admin.html
+++ b/server/templates/admin.html
@@ -58,6 +58,14 @@ limitations under the License.
     </div>
 
     <br><hr><br>
+
+    <h2>Configuration</h2>
+      <div>Training Enabled: <span id="trainingEnabled">{{config['training_enabled']}}</span></div>
+      <div>Use TPU: <span id="useTpu">{{config['use_tpu']}}</span></div>
+      <div>Secure Session Cookies: <span id="secureSessionCookies">{{config['secure_session_cookies']}}</span></div>
+      <div>Samesite Session Cookies: <span id="samesiteSessionCookies">{{config['samesite_session_cookies']}}</span></div>
+      <button id="refreshConfigButton" class="btn btn-secondary">Refresh</button>
+      <br><hr><br>
   </div>
 
 <script type="text/javascript">

--- a/server/templates/layout.html
+++ b/server/templates/layout.html
@@ -40,6 +40,9 @@ limitations under the License.
             <div id="navbarSupportedContent" class="collapse navbar-collapse">
                 <div class="navbar-nav" style="margin-left: auto !important;">
                     <ul class="navbar-nav">
+                        {% if is_admin %}
+                            <li class="nav-item"><a class="nav-link" href="/admin">Admin</a></li>
+                        {% endif %}
                         <li class="nav-item"><a class="nav-link" href="/resources">Resources</a></li>
                         <li class="nav-item"><a class="nav-link" href="https://community.ftclive.org">Help/Feedback</a></li>
                         <li class="nav-item" id="logoutListItem"><span class="nav-link" id="logoutButton">Hello, {{name}}&nbsp;{{program}}&nbsp;Team&nbsp;{{team_number}}</span></li>


### PR DESCRIPTION
Adds the ability to refresh the configuration cache at runtime.  To support this, the Config class is turned into a pure dictionary, with custom set/get methods that will populate and retrieve from a redis server if so configured, otherwise it acts as the default dictionary.

