### PR TITLE
Session fix

### DIFF
--- a/server/app_engine.py
+++ b/server/app_engine.py
@@ -127,13 +127,8 @@ application_properties = json.load(open('app.properties', 'r'))
 @app.context_processor
 def inject_time():
     program, team_number = team_info.retrieve_program_and_team_number(flask.session)
-    if 'user_roles' in flask.session:
-        is_admin = roles.is_global_admin(flask.session.get('user_roles'))
-    else:
-        is_admin = False
     return dict(time_time=time.time(), project_id=constants.PROJECT_ID, name=flask.session.get('given_name'),
-                program=program, team_number=team_number, is_admin=is_admin,
-                version=application_properties.get('version'),
+                program=program, team_number=team_number, version=application_properties.get('version'),
                 announcements=announcements.get_unexpired_announcements())
 
 

--- a/server/oidc.py
+++ b/server/oidc.py
@@ -61,7 +61,11 @@ def logout():
 
 
 def is_user_loggedin():
-    return oidc_handle.user_loggedin
+    if is_using_oidc():
+        return oidc_handle.user_loggedin
+    else:
+        # Go ahead and be permissive if we aren't using oidc.
+        return True
 
 
 def user_getfield(token):


### PR DESCRIPTION
A partial logout can lead to a scenario where ftc-ml displays "Forbidden".

If you perform the following steps...

1. Log in to ftc-ml
2. Click your name to redirect to the ftc-scoring account page
3. Click the browser's back button

You eventually end up here....

![image](https://user-images.githubusercontent.com/1435639/140190544-d3a468b2-0155-48ca-a195-d09de5ca3a1a.png)

This happens because ftc-ml thinks you are logged out, but ftc-scoring still has a session going for you.

This PR kicks the server over to the login endpoint which refreshes the session within ftc-ml.  If you are still logged in the ftc-scoring when this happens it is transparent.