### PR TITLE
Fixed issues related to labeling frames and tracking

### DIFF
--- a/server/app_engine.py
+++ b/server/app_engine.py
@@ -977,7 +977,7 @@ def prepare_to_start_tracking():
 @handle_exceptions
 @login_required
 def retrieve_tracked_bboxes():
-    time_limit = datetime.now(timezone.utc) + timedelta(seconds=25)
+    time_limit = datetime.now(timezone.utc) + timedelta(seconds=15)
     data = validate_keys(flask.request.form.to_dict(flat=True),
         ['video_uuid', 'tracker_uuid', 'retrieve_frame_number'])
     video_uuid = storage.validate_uuid(data.get('video_uuid'))
@@ -998,7 +998,7 @@ def retrieve_tracked_bboxes():
 @handle_exceptions
 @login_required
 def continue_tracking():
-    time_limit = datetime.now(timezone.utc) + timedelta(seconds=25)
+    time_limit = datetime.now(timezone.utc) + timedelta(seconds=15)
     team_uuid = team_info.retrieve_team_uuid(flask.session, flask.request)
     data = validate_keys(flask.request.form.to_dict(flat=True),
         ['video_uuid', 'tracker_uuid', 'frame_number', 'bboxes_text'], optional_keys=['retrieve_frame_number'])

--- a/server/storage.py
+++ b/server/storage.py
@@ -360,23 +360,23 @@ def retrieve_video_entity_for_labeling(team_uuid, video_uuid):
             tracker_entity = maybe_retrieve_tracker_entity(video_uuid, tracker_uuid)
             if tracker_entity is None:
                 tracking_in_progress = False
-                logging.critical('Tracker is not in progress. Tracker entity is missing.')
+                logging.warning('Tracker is not in progress. Tracker entity is missing.')
             else:
                 # If it's been more than two minutes, assume the tracker has died.
                 timedelta_since_last_update = datetime.now(timezone.utc) - tracker_entity['update_time']
                 if timedelta_since_last_update > timedelta(minutes=2):
-                    logging.critical('Tracker is not in progress. Elapsed time since last tracker update: %f seconds' %
+                    logging.warning('Tracker is not in progress. Elapsed time since last tracker update: %f seconds' %
                         timedelta_since_last_update.total_seconds())
                     tracking_in_progress = False
             tracker_client_entity = maybe_retrieve_tracker_client_entity(video_uuid, tracker_uuid)
             if tracker_client_entity is None:
                 tracking_in_progress = False
-                logging.critical('Tracker is not in progress. Tracker client entity is missing.')
+                logging.warning('Tracker is not in progress. Tracker client entity is missing.')
             else:
                 # If it's been more than two minutes, assume the tracker client is not connected.
                 timedelta_since_last_update = datetime.now(timezone.utc) - tracker_client_entity['update_time']
                 if timedelta_since_last_update > timedelta(minutes=2):
-                    logging.critical('Tracker is not in progress. Elapsed time since last tracker client update: %f seconds' %
+                    logging.warning('Tracker is not in progress. Elapsed time since last tracker client update: %f seconds' %
                         timedelta_since_last_update.total_seconds())
                     tracking_in_progress = False
             if not tracking_in_progress:
@@ -732,7 +732,7 @@ def retrieve_tracked_bboxes(video_uuid, tracker_uuid, retrieve_frame_number, tim
     tracker_entity = maybe_retrieve_tracker_entity(video_uuid, tracker_uuid)
     while True:
         if tracker_entity is None:
-            logging.critical('Tracker appears to have failed. Tracker entity is missing.')
+            logging.warning('Tracker appears to have failed. Tracker entity is missing.')
             return True, 0, ''
         if tracker_entity['frame_number'] == retrieve_frame_number:
             break
@@ -741,7 +741,7 @@ def retrieve_tracked_bboxes(video_uuid, tracker_uuid, retrieve_frame_number, tim
         # If it's been more than two minutes, assume the tracker has died.
         timedelta_since_last_update = datetime.now(timezone.utc) - tracker_entity['update_time']
         if timedelta_since_last_update > timedelta(minutes=2):
-            logging.critical('Tracker appears to have failed. Elapsed time since last tracker update: %f seconds' %
+            logging.warning('Tracker appears to have failed. Elapsed time since last tracker update: %f seconds' %
                 timedelta_since_last_update.total_seconds())
             tracker_stopping(tracker_entity['team_uuid'], tracker_entity['video_uuid'], tracker_uuid)
             tracker_failed = True


### PR DESCRIPTION
Reduced the time limit for retrieveTrackedBboxes and continueTracking from 25 seconds to 15 seconds.

This will fix the issue with these requests taking longer than 30 seconds and being aborted.

Changed non-error tracker logging from critical to warning.

Fixed bug where typing a label name quickly causes unlabeled frame count to be incorrect.

If the tracker doesn't find all the objects, automatically pause tracking.