### PR TITLE
Changed the blob directory structure

### DIFF
--- a/server/app_engine/action.py
+++ b/server/app_engine/action.py
@@ -61,14 +61,12 @@ ACTION_NAME_RESET_REMAINING_TRAINING_MINUTES = 'reset_remaining_training_minutes
 ACTION_NAME_INCREMENT_REMAINING_TRAINING_MINUTES = 'increment_remaining_training_minutes'
 ACTION_NAME_SAVE_END_OF_SEASON_ENTITIES = 'save_end_of_season_entities'
 ACTION_NAME_RESET_TEAM_ENTITIES = 'reset_team_entities'
-ACTION_NAME_EXPUNGE_BLOB_STORAGE = 'expunge_blob_storage'
 
 def create_action_parameters(team_uuid, action_name):
     if (action_name == ACTION_NAME_RESET_REMAINING_TRAINING_MINUTES or
             action_name == ACTION_NAME_INCREMENT_REMAINING_TRAINING_MINUTES or
             action_name == ACTION_NAME_SAVE_END_OF_SEASON_ENTITIES or
             action_name == ACTION_NAME_RESET_TEAM_ENTITIES or
-            action_name == ACTION_NAME_EXPUNGE_BLOB_STORAGE or
             action_name == ACTION_NAME_TEST):
         is_admin_action = True
     else:

--- a/server/app_engine/model_trainer.py
+++ b/server/app_engine/model_trainer.py
@@ -457,7 +457,6 @@ def retrieve_tags_and_steps(team_uuid, model_uuid, job_type, value_type):
     # storage.retrieve_model_entity will raise HttpErrorNotFound
     # if the team_uuid/model_uuid is not found.
     model_entity = storage.retrieve_model_entity(team_uuid, model_uuid)
-    model_folder = model_entity['model_folder']
     list_of_summary_items = storage.get_model_summary_items_all_steps(model_entity, job_type, value_type)
     step_and_tag_pairs = []
     for summary_items in list_of_summary_items:

--- a/server/app_engine/templates/admin.html
+++ b/server/app_engine/templates/admin.html
@@ -117,40 +117,13 @@ limitations under the License.
     <br><hr><br>
 
     <h2>Expunge blob storage</h2>
-    <h4>Team UUID Prefixes</h4>
-    <div>
-      <input type="checkbox" id="team_uuid_0" checked="true" />&nbsp;<label for="team_uuid_0" class="text-22">0</label><br>
-      <input type="checkbox" id="team_uuid_1" checked="true" />&nbsp;<label for="team_uuid_1" class="text-22">1</label><br>
-      <input type="checkbox" id="team_uuid_2" checked="true" />&nbsp;<label for="team_uuid_2" class="text-22">2</label><br>
-      <input type="checkbox" id="team_uuid_3" checked="true" />&nbsp;<label for="team_uuid_3" class="text-22">3</label><br>
-      <input type="checkbox" id="team_uuid_4" checked="true" />&nbsp;<label for="team_uuid_4" class="text-22">4</label><br>
-      <input type="checkbox" id="team_uuid_5" checked="true" />&nbsp;<label for="team_uuid_5" class="text-22">5</label><br>
-      <input type="checkbox" id="team_uuid_6" checked="true" />&nbsp;<label for="team_uuid_6" class="text-22">6</label><br>
-      <input type="checkbox" id="team_uuid_7" checked="true" />&nbsp;<label for="team_uuid_7" class="text-22">7</label><br>
-      <input type="checkbox" id="team_uuid_8" checked="true" />&nbsp;<label for="team_uuid_8" class="text-22">8</label><br>
-      <input type="checkbox" id="team_uuid_9" checked="true" />&nbsp;<label for="team_uuid_9" class="text-22">9</label><br>
-      <input type="checkbox" id="team_uuid_a" checked="true" />&nbsp;<label for="team_uuid_a" class="text-22">a</label><br>
-      <input type="checkbox" id="team_uuid_b" checked="true" />&nbsp;<label for="team_uuid_b" class="text-22">b</label><br>
-      <input type="checkbox" id="team_uuid_c" checked="true" />&nbsp;<label for="team_uuid_c" class="text-22">c</label><br>
-      <input type="checkbox" id="team_uuid_d" checked="true" />&nbsp;<label for="team_uuid_d" class="text-22">d</label><br>
-      <input type="checkbox" id="team_uuid_e" checked="true" />&nbsp;<label for="team_uuid_e" class="text-22">e</label><br>
-      <input type="checkbox" id="team_uuid_f" checked="true" />&nbsp;<label for="team_uuid_f" class="text-22">f</label><br>
-    </div>
-    <div><input type="checkbox" id="keepTfLiteFilesCheckbox" checked="true" />
-      <label for="keepTfLiteFilesCheckbox" class="text-22">Keep TFLite files (do not delete them)</label>
-    </div>
-    <br>
-    <button id="expungeBlobStorageButton" class="btn btn-secondary">Expunge Blob Storage</button>
-    <div id="expungeBlobStorageResponse"></div>
-    <div id="expungeBlobStorageMonitorInfo" style="display: none">
-        The action to expunge blob storage has been triggered.<br><br>
-        You should monitor the AdminAction entities (in the datastore) with the <i>action_uuid</i>
-        values<ul>
-          <li><span id="expungeBlobStorageActionUuids" class="fw-bold"></span></li>
-        </ul>
-        When the <i>state</i> fields become &quot;finished&quot;, the expunging is either
-        finished, or it encountered an error. Check the Cloud Console for logs.
-    </div>
+    <div>Please use the Cloud Console to delete the following Storage folders:<ul>
+        <li>2022_2023/dataset_zips</li>
+        <li>2022_2023/image_files</li>
+        <li>2022_2023/models</li>
+        <li>2022_2023/tf_records</li>
+        <li>2022_2023/video_files</li>
+    </ul></div>
 
     <br><hr><br>
 

--- a/server/cf_action.py
+++ b/server/cf_action.py
@@ -65,7 +65,6 @@ def __perform_action(action_parameters, time_limit):
         action.ACTION_NAME_INCREMENT_REMAINING_TRAINING_MINUTES: storage.increment_remaining_training_minutes,
         action.ACTION_NAME_SAVE_END_OF_SEASON_ENTITIES: storage.save_end_of_season_entities,
         action.ACTION_NAME_RESET_TEAM_ENTITIES: storage.reset_team_entities,
-        action.ACTION_NAME_EXPUNGE_BLOB_STORAGE: blob_storage.expunge_blob_storage,
     }
     action_fn = action_fns.get(action_parameters[action.ACTION_NAME], None)
     if action_fn is not None:

--- a/server/src/js/admin.js
+++ b/server/src/js/admin.js
@@ -57,20 +57,6 @@ fmltc.Admin = function() {
   this.resetTeamEntitiesActionUuid = document.getElementById('resetTeamEntitiesActionUuid');
   this.resetTeamEntitiesButton.onclick = this.resetTeamEntitiesButton_onclick.bind(this);
 
-  this.team_uuid_prefix_checkboxes = [];
-  const uuid_chars = '0123456789abcdef';
-  for (var i = 0; i < uuid_chars.length; i++) {
-    const ch = uuid_chars.charAt(i);
-    const checkbox = document.getElementById('team_uuid_' + ch);
-    this.team_uuid_prefix_checkboxes.push(checkbox);
-  }
-  this.keepTfLiteFilesCheckbox = document.getElementById('keepTfLiteFilesCheckbox');
-  this.expungeBlobStorageButton = document.getElementById('expungeBlobStorageButton');
-  this.expungeBlobStorageResponse = document.getElementById('expungeBlobStorageResponse');
-  this.expungeBlobStorageMonitorInfo = document.getElementById('expungeBlobStorageMonitorInfo');
-  this.expungeBlobStorageActionUuids = document.getElementById('expungeBlobStorageActionUuids');
-  this.expungeBlobStorageButton.onclick = this.expungeBlobStorageButton_onclick.bind(this);
-
   this.confirmationDialog = document.getElementById('confirmationDialog');
   this.confirmationTitle = document.getElementById('confirmationTitle');
   this.confirmationXButton = document.getElementById('confirmationXButton');
@@ -107,12 +93,6 @@ fmltc.Admin.prototype.enableInputsAndButtons = function(enable) {
   this.saveEndOfSeasonEntitiesButton.disabled = !enable;
 
   this.resetTeamEntitiesButton.disabled = !enable;
-
-  for (var i = 0; i < this.team_uuid_prefix_checkboxes.length; i++) {
-    this.team_uuid_prefix_checkboxes[i].disabled = !enable;
-  }
-  this.keepTfLiteFilesCheckbox.disabled = !enable;
-  this.expungeBlobStorageButton.disabled = !enable;
 
   this.refreshConfigButton.disables = !enable;
 };
@@ -215,20 +195,6 @@ fmltc.Admin.prototype.resetTeamEntitiesButton_onclick = function() {
   this.confirmationCallback = this.resetTeamEntities.bind(this);
 };
 
-fmltc.Admin.prototype.expungeBlobStorageButton_onclick = function() {
-  this.confirmationTitle.textContent = 'Expunge Blob Storage';
-  let message = 'Are you sure you want to delete all blobs';
-  if (this.keepTfLiteFilesCheckbox.checked) {
-    message += ', except TFLite files';
-  }
-  message += '?';
-  this.confirmationAreYouSure.textContent = message;
-  this.confirmationInput.value = '';
-  this.confirmationYesButton.disabled = true;
-  this.confirmationDialog.style.display = 'block';
-  this.confirmationCallback = this.expungeBlobStorage.bind(this);
-};
-
 fmltc.Admin.prototype.confirmationInput_oninput = function() {
   this.confirmationYesButton.disabled = (this.confirmationInput.value != 'Confirm');
 };
@@ -278,45 +244,6 @@ fmltc.Admin.prototype.xhr_resetTeamEntities_onreadystatechange = function(xhr, p
 
     } else {
       this.resetTeamEntitiesResponse.textContent = 'Failure - status: ' + xhr.status + ', statusText: ' + xhr.status;
-    }
-  }
-};
-
-fmltc.Admin.prototype.expungeBlobStorage = function() {
-  this.enableInputsAndButtons(false);
-
-  let team_uuid_prefixes = [];
-  for (var i = 0; i < this.team_uuid_prefix_checkboxes.length; i++) {
-    if (this.team_uuid_prefix_checkboxes[i].checked) {
-      const id = this.team_uuid_prefix_checkboxes[i].id;
-      if (id.startsWith('team_uuid_')) {
-        const char = id.substring(10); // length of 'team_uuid_' is 10.
-        team_uuid_prefixes.push(char);
-      }
-    }
-  }
-
-  const xhr = new XMLHttpRequest();
-  const params = 'keep_tflite_and_labels=' + this.keepTfLiteFilesCheckbox.checked +
-      '&team_uuid_prefixes=' + encodeURIComponent(team_uuid_prefixes.join(',')) +
-      '&date_time_string=' + encodeURIComponent(new Date().toLocaleString());
-  xhr.open('POST', '/expungeBlobStorage', true);
-  xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
-  xhr.onreadystatechange = this.xhr_expungeBlobStorage_onreadystatechange.bind(this, xhr, params);
-  xhr.send(params);
-};
-
-fmltc.Admin.prototype.xhr_expungeBlobStorage_onreadystatechange = function(xhr, params) {
-  if (xhr.readyState === 4) {
-    xhr.onreadystatechange = null;
-
-    if (xhr.status === 200) {
-      const response = JSON.parse(xhr.responseText);
-      this.expungeBlobStorageActionUuids.textContent = response.action_uuids.join(', ');
-      this.expungeBlobStorageMonitorInfo.style.display = 'block';
-
-    } else {
-      this.expungeBlobStorageResponse.textContent = 'Failure - status: ' + xhr.status + ', statusText: ' + xhr.status;
     }
   }
 };


### PR DESCRIPTION
Changed the blob directory structure to make cleaning up before the next season easier. Blobs are now put in the following structure:

- 2022_2023
    - video_files
    - image_files
    - tf_records
    - dataset_zips
    - models
    - tflite_files

Removed the admin action that deleted blobs as it won't be needed. With the changes in the blob directory structure, deleting blobs can be done more efficiently in the cloud console.