### PR TITLE
Convert images from TF evaluation to compressed jpegs

### DIFF
--- a/server/cf_dataset_producer.py
+++ b/server/cf_dataset_producer.py
@@ -307,16 +307,14 @@ def __write_record(team_uuid, sorted_label_list, frame_number_list, frame_data_d
 
 
 def __create_tf_example(frame_data, sorted_label_list):
+    # frame_data.image is a numpy.ndarray. Convert it to bytes.
     im = PIL.Image.open(io.BytesIO(frame_data.image))
     arr = io.BytesIO()
-    if frame_data.format == 'jpg':
-      format = 'JPEG'
-    else:
-      format = frame_data.format.upper()
-    im.save(arr, format=format)
+    im.save(arr, format=frame_data.format)
     height = im.height
     width = im.width
     encoded_image_data = arr.getvalue()
+
     rects, labels = bbox_writer.convert_text_to_rects_and_labels(frame_data.bboxes_text)
     # List of normalized coordinates, 1 per box, capped to [0, 1]
     xmins = [max(min(rect[0] / width, 1), 0) for rect in rects] # left x

--- a/server/cf_model_trainer.py
+++ b/server/cf_model_trainer.py
@@ -17,11 +17,13 @@ __author__ = "lizlooney@google.com (Liz Looney)"
 # Python Standard Library
 from datetime import datetime, timedelta, timezone
 import dateutil.parser
+import io
 import math
 import time
 
 # Other Modules
 from google.api_core.exceptions import GoogleAPIError
+import PIL.Image
 import tensorflow as tf
 from tensorflow.core.util import event_pb2
 
@@ -183,9 +185,15 @@ def __monitor_training_for_event_file(model_folder, job_type, event_file_path, a
                 width = int(float(image_value[0].decode('utf-8')))
                 height = int(float(image_value[1].decode('utf-8')))
                 image_bytes = image_value[2]
-                # There might be more than one image, but we only look at the first one.
+
+                # Convert to JPEG with lower quality.
+                im = PIL.Image.open(io.BytesIO(image_bytes))
+                arr = io.BytesIO()
+                im.save(arr, format='JPEG', quality=50)
+                jpeg_image_bytes = arr.getvalue()
+
                 blob_storage.store_event_summary_image(model_folder, job_type,
-                    event.step, value.tag, image_bytes)
+                    event.step, value.tag, jpeg_image_bytes)
                 item = {
                     'job_type': job_type,
                     'step': event.step,


### PR DESCRIPTION
In cf_dataset_producer.py:
Added a comment explaining why we convert the frame_data_image using PIL.Image. Removed special code for jpg format since we use png for the dataset.

In cf_model_trainer.py:
Added code to convert the image we get back from TensorFlow evaluation to JPEG with lower quality. The JPEG images are about 25% of the size of the ones from TensorFlow.